### PR TITLE
Fixing path on examples.

### DIFF
--- a/examples/demos/sunburst/index.js
+++ b/examples/demos/sunburst/index.js
@@ -7,7 +7,7 @@ import { scaleLinear, scaleSqrt, scaleOrdinal } from 'd3-scale'
 import { schemeCategory10 as scheme } from 'd3-scale-chromatic'
 import { interpolate as d3interpolate } from 'd3-interpolate'
 import { Spring, animated } from 'react-spring'
-import Partition from './Partition'
+import Partition from './partition'
 import data from './data'
 import './styles.css'
 


### PR DESCRIPTION

@drcmda Hi, I was trying make the build the examples on my machine and I'm seeing this a typo to import a component 'Partition'. 

```
ERROR in ./demos/sunburst/index.js
Module not found: Error: Can't resolve './Partition' in '/home/leonardo/Documents/react-spring/examples/demos/sunburst'
 @ ./demos/sunburst/index.js 10:0-36 101:27-36
 @ ./demos lazy ^\.\/.*$ namespace object
 @ ./index.js
 @ multi (webpack)-dev-server/client?http://localhost:8080 index.js
ℹ ｢wdm｣: Failed to compile.

```