### PR TITLE
Add babel runtime to reuse helpers across packages

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,40 +1,30 @@
 {
-  "dist/react-spring.js": {
-    "bundled": 66578,
-    "minified": 31479,
-    "gzipped": 9095
-  },
   "dist/react-spring.es.js": {
-    "bundled": 66152,
-    "minified": 31130,
-    "gzipped": 8996,
+    "bundled": 64326,
+    "minified": 30244,
+    "gzipped": 8668,
     "treeshaked": {
-      "rollup": 27105,
-      "webpack": 27814
+      "rollup": 26254,
+      "webpack": 27242
     }
   },
   "dist/react-spring.umd.js": {
-    "bundled": 75045,
-    "minified": 33241,
-    "gzipped": 11091
-  },
-  "dist/addons.cjs.js": {
-    "bundled": 14847,
-    "minified": 6899,
-    "gzipped": 2313
+    "bundled": 75460,
+    "minified": 33351,
+    "gzipped": 11111
   },
   "dist/addons.js": {
-    "bundled": 14706,
-    "minified": 6772,
-    "gzipped": 2262,
+    "bundled": 14595,
+    "minified": 6741,
+    "gzipped": 2258,
     "treeshaked": {
-      "rollup": 1972,
-      "webpack": 2538
+      "rollup": 2036,
+      "webpack": 2628
     }
   },
   "dist/addons.umd.js": {
-    "bundled": 15119,
-    "minified": 6130,
-    "gzipped": 2183
+    "bundled": 15154,
+    "minified": 6131,
+    "gzipped": 2181
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "homepage": "https://github.com/drcmda/react-spring#readme",
     "devDependencies": {
         "@babel/core": "7.0.0-beta.44",
-        "@babel/plugin-transform-runtime": "7.0.0-beta.44",
+        "@babel/plugin-transform-runtime": "^7.0.0-beta.44",
         "@babel/preset-env": "7.0.0-beta.44",
         "@babel/preset-react": "7.0.0-beta.44",
         "@babel/preset-stage-2": "7.0.0-beta.44",
@@ -52,6 +52,7 @@
         "react": ">= 16.0.0"
     },
     "dependencies": {
+        "@babel/runtime": "^7.0.0-beta.44",
         "normalize-css-color": "^1.0.2"
     }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,26 +5,27 @@ import uglify from 'rollup-plugin-uglify'
 import { sizeSnapshot } from 'rollup-plugin-size-snapshot'
 import pkg from './package.json'
 
-const getBabelOptions = (modules = false, loose = true) => ({
+const getBabelOptions = ({ useESModules }) => ({
     babelrc: false,
+    runtimeHelpers: true,
     presets: [
         ['@babel/preset-env', { loose: true, modules: false }],
         ['@babel/preset-stage-2', { loose: true }],
         '@babel/preset-react',
     ],
-    plugins: ['transform-react-remove-prop-types'],
+    plugins: [
+      ['@babel/transform-runtime', { polyfill: false, useBuiltIns: true, useESModules }],
+      'transform-react-remove-prop-types',
+    ],
 })
 
-const isExternal = id => !id.startsWith('\0') && !id.startsWith('.') && !id.startsWith('/')
+const isExternal = id => !id.startsWith('.') && !id.startsWith('/')
 
 const plugins = [
-    babel(getBabelOptions()),
+    babel(getBabelOptions({ useESModules: false })),
     resolve(),
     commonjs(),
-    sizeSnapshot()
-]
-
-const compress = [
+    sizeSnapshot(),
     uglify({
         compress: true,
         mangle: {
@@ -33,34 +34,50 @@ const compress = [
     }),
 ]
 
+const peers = [...Object.keys(pkg.peerDependencies || {})]
+
 const globals = { 'react': 'React', 'prop-types': 'PropTypes' }
 
 export default [
     {
         input: './src/index.js',
-        output: [{ file: `${pkg.main}.js`, format: 'cjs' }, { file: `${pkg.module}.js`, format: 'es' }],
+        output: { file: `${pkg.main}.js`, format: 'cjs' },
         external: isExternal,
-        plugins,
+        plugins: [babel(getBabelOptions({ useESModules: false }))],
     },
 
     {
         input: './src/index.js',
-        output: [{ file: `${pkg.main}.umd.js`, format: 'umd', name: 'ReactSpring', globals }],
-        external: [...Object.keys(pkg.peerDependencies || {})],
-        plugins: [...plugins, ...compress],
+        output: { file: `${pkg.module}.js`, format: 'es' },
+        external: isExternal,
+        plugins: [babel(getBabelOptions({ useESModules: true })), sizeSnapshot()],
+    },
+
+    {
+        input: './src/index.js',
+        output: { file: `${pkg.main}.umd.js`, format: 'umd', name: 'ReactSpring', globals },
+        external: peers,
+        plugins,
     },
 
     {
         input: './src/addons/index.js',
-        output: [{ file: `dist/addons.cjs.js`, format: 'cjs' }, { file: `dist/addons.js`, format: 'es' }],
+        output: { file: `dist/addons.cjs.js`, format: 'cjs' },
         external: isExternal,
-        plugins,
+        plugins: [babel(getBabelOptions({ useESModules: false }))],
+    },
+
+    {
+        input: './src/addons/index.js',
+        output: { file: `dist/addons.js`, format: 'es' },
+        external: isExternal,
+        plugins: [babel(getBabelOptions({ useESModules: true })), sizeSnapshot()],
     },
 
     {
         input: './src/addons/index.js',
         output: { file: `dist/addons.umd.js`, format: 'umd', name: 'ReactSpringAddons', globals },
-        external: [...Object.keys(pkg.peerDependencies || {})],
-        plugins: [...plugins, ...compress],
+        external: peers,
+        plugins,
     },
 ]

--- a/src/animated/targets/react-dom.js
+++ b/src/animated/targets/react-dom.js
@@ -1,4 +1,4 @@
-import Animated from '../'
+import Animated from '../index.js'
 
 const isUnitlessNumber = {
     animationIterationCount: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -502,7 +502,7 @@
   dependencies:
     regenerator-transform "^0.12.3"
 
-"@babel/plugin-transform-runtime@7.0.0-beta.44":
+"@babel/plugin-transform-runtime@^7.0.0-beta.44":
   version "7.0.0-beta.44"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.0.0-beta.44.tgz#13c7289c393425cc3bc99c9a0e836ca45f014c1f"
   dependencies:
@@ -627,6 +627,13 @@
     "@babel/plugin-proposal-unicode-property-regex" "7.0.0-beta.44"
     "@babel/plugin-syntax-dynamic-import" "7.0.0-beta.44"
     "@babel/plugin-syntax-import-meta" "7.0.0-beta.44"
+
+"@babel/runtime@^7.0.0-beta.44":
+  version "7.0.0-beta.44"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.44.tgz#ea5ad6c6fe9a2c1187b025bf42424d28050ee696"
+  dependencies:
+    core-js "^2.5.3"
+    regenerator-runtime "^0.11.1"
 
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
@@ -1302,6 +1309,10 @@ core-js@^1.0.0:
 core-js@^2.4.0:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
+
+core-js@^2.5.3:
+  version "2.5.5"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.5.tgz#b14dde936c640c0579a6b50cabcc132dd6127e3b"
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
@@ -3006,7 +3017,7 @@ regenerate@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.3.tgz#0c336d3980553d755c39b586ae3b20aa49c82b7f"
 
-regenerator-runtime@^0.11.0:
+regenerator-runtime@^0.11.0, regenerator-runtime@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 


### PR DESCRIPTION
- removed cjs snapshots because they are almost the same as es expect a few bytes for interop
- added babel-runtime
- simplified esm/cjs rollup plugins list
- splitted esm/cjs outputs to allow passing different options to babel

As you can see the esm size from previous PR 30536 B is reduced to 30244 B however these files contains these long paths, so the real result is even better.

```js
import _objectSpread from '@babel/runtime/helpers/builtin/es6/objectSpread';
import _inheritsLoose from '@babel/runtime/helpers/builtin/es6/inheritsLoose';
import _extends from '@babel/runtime/helpers/builtin/es6/extends';
import _objectWithoutProperties from '@babel/runtime/helpers/builtin/es6/objectWithoutProperties';
import _assertThisInitialized from '@babel/runtime/helpers/builtin/es6/assertThisInitialized';
```