### PR TITLE
Replace string refs with callback refs

### DIFF
--- a/examples/demos/parallax/index.js
+++ b/examples/demos/parallax/index.js
@@ -31,7 +31,7 @@ const Page = ({ offset, caption, first, second, gradient, onClick }) => (
 )
 
 export default class extends React.Component {
-  scroll = to => this.refs.parallax.scrollTo(to)
+  scroll = to => this.parallax.scrollTo(to)
   render() {
     return (
       <div
@@ -43,7 +43,7 @@ export default class extends React.Component {
       >
         <Parallax
           className="container"
-          ref="parallax"
+          ref={node => (this.parallax = node)}
           pages={3}
           horizontal
           scrolling={false}

--- a/src/Parallax.js
+++ b/src/Parallax.js
@@ -55,15 +55,12 @@ export default class Parallax extends React.PureComponent {
   update = () => {
     const { scrolling, horizontal } = this.props
     const scrollType = getScrollType(horizontal)
-    if (!this.refs.container) return
-    this.space = this.refs.container[
-      horizontal ? 'clientWidth' : 'clientHeight'
-    ]
-    if (scrolling) this.current = this.refs.container[scrollType]
-    else
-      this.refs.container[scrollType] = this.current = this.offset * this.space
-    if (this.refs.content)
-      this.refs.content.style[horizontal ? 'width' : 'height'] = `${this.space *
+    if (!this.container) return
+    this.space = this.container[horizontal ? 'clientWidth' : 'clientHeight']
+    if (scrolling) this.current = this.container[scrollType]
+    else this.container[scrollType] = this.current = this.offset * this.space
+    if (this.content)
+      this.content.style[horizontal ? 'width' : 'height'] = `${this.space *
         this.props.pages}px`
     this.layers.forEach(layer => {
       layer.setHeight(this.space, true)
@@ -85,7 +82,7 @@ export default class Parallax extends React.PureComponent {
     const scrollType = getScrollType(horizontal)
     this.scrollStop()
     this.offset = offset
-    const target = this.refs.container
+    const target = this.container
     this.animatedScroll = new Animated.Value(target[scrollType])
     this.animatedScroll.addListener(({ value }) => (target[scrollType] = value))
     Animated.controller(
@@ -126,7 +123,7 @@ export default class Parallax extends React.PureComponent {
     const overflow = scrolling ? 'scroll' : 'hidden'
     return (
       <div
-        ref="container"
+        ref={node => (this.container = node)}
         onScroll={this.onScroll}
         onWheel={scrolling ? this.scrollStop : null}
         onTouchStart={scrolling ? this.scrollStop : null}
@@ -147,7 +144,7 @@ export default class Parallax extends React.PureComponent {
       >
         {this.state.ready && (
           <div
-            ref="content"
+            ref={node => this.node}
             style={{
               position: 'absolute',
               [horizontal ? 'height' : 'width']: '100%',
@@ -254,7 +251,6 @@ export default class Parallax extends React.PureComponent {
       return (
         <animated.div
           {...props}
-          ref="layer"
           className={className}
           style={{
             position: 'absolute',

--- a/src/animated/createAnimatedComponent.js
+++ b/src/animated/createAnimatedComponent.js
@@ -2,8 +2,6 @@ import React from 'react'
 import AnimatedProps from './AnimatedProps'
 import ApplyAnimatedValues from './injectable/ApplyAnimatedValues'
 
-const refName = 'node'
-
 export default function createAnimatedComponent(Component) {
   return class AnimatedComponent extends React.Component {
     static propTypes = {
@@ -17,11 +15,7 @@ export default function createAnimatedComponent(Component) {
     }
 
     setNativeProps(props) {
-      var didUpdate = ApplyAnimatedValues.current(
-        this.refs['node'],
-        props,
-        this
-      )
+      var didUpdate = ApplyAnimatedValues.current(this.node, props, this)
       if (didUpdate === false) this.forceUpdate()
     }
 
@@ -40,7 +34,7 @@ export default function createAnimatedComponent(Component) {
       // forceUpdate.
       var callback = () => {
         const didUpdate = ApplyAnimatedValues.current(
-          this.refs['node'],
+          this.node,
           this._propsAnimated.__getAnimatedValue(),
           this
         )
@@ -70,7 +64,7 @@ export default function createAnimatedComponent(Component) {
         <Component
           {...other}
           style={ApplyAnimatedValues.transformStyles(style)}
-          ref="node"
+          ref={node => (this.node = node)}
         />
       )
     }


### PR DESCRIPTION
Let's change to callback refs until major release with react 16.3 restriction.