### PR TITLE
Export parallax layer and tweak docs and examples to it

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,17 +1,17 @@
 {
   "dist/react-spring.es.js": {
-    "bundled": 64938,
-    "minified": 30445,
-    "gzipped": 8706,
+    "bundled": 65015,
+    "minified": 30459,
+    "gzipped": 8712,
     "treeshaked": {
-      "rollup": 25657,
-      "webpack": 26644
+      "rollup": 25651,
+      "webpack": 26635
     }
   },
   "dist/react-spring.umd.js": {
-    "bundled": 86386,
-    "minified": 37622,
-    "gzipped": 12507
+    "bundled": 86487,
+    "minified": 37632,
+    "gzipped": 12509
   },
   "dist/addons.js": {
     "bundled": 14595,

--- a/API.md
+++ b/API.md
@@ -22,29 +22,41 @@ import { Spring } from 'react-spring'
 
 ```jsx
 class Spring extends React.PureComponent {
-    static propTypes = {
-        // Spring config ({ tension, friction })
-        config: PropTypes.object,
-        // Will skip rendering the component if true and write to the dom directly
-        native: PropTypes.bool,
-        // Base styles, optional
-        from: PropTypes.object,
-        // Animates to ...
-        to: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
-        // Callback when the animation comes to a still-stand
-        onRest: PropTypes.func,
-        // Frame by frame callback, first argument passed is the animated value
-        onFrame: PropTypes.func,
-        // Takes a function that receives interpolated styles
-        children: PropTypes.oneOfType([PropTypes.func, PropTypes.arrayOf(PropTypes.func)]),
-        // Same as children, but takes precedence if present
-        render: PropTypes.func,
-        // Prevents animation if true, you can also pass individual keys
-        immediate: PropTypes.oneOfType([PropTypes.bool, PropTypes.arrayOf(PropTypes.string)]),
-        // When true it literally resets: from -> to
-        reset: PropTypes.bool,
-    }
-    static defaultProps = { from: {}, to: {}, config: config.default, native: false, immediate: false }
+  static propTypes = {
+    // Spring config ({ tension, friction })
+    config: PropTypes.object,
+    // Will skip rendering the component if true and write to the dom directly
+    native: PropTypes.bool,
+    // Base styles, optional
+    from: PropTypes.object,
+    // Animates to ...
+    to: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+    // Callback when the animation comes to a still-stand
+    onRest: PropTypes.func,
+    // Frame by frame callback, first argument passed is the animated value
+    onFrame: PropTypes.func,
+    // Takes a function that receives interpolated styles
+    children: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.arrayOf(PropTypes.func),
+    ]),
+    // Same as children, but takes precedence if present
+    render: PropTypes.func,
+    // Prevents animation if true, you can also pass individual keys
+    immediate: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.arrayOf(PropTypes.string),
+    ]),
+    // When true it literally resets: from -> to
+    reset: PropTypes.bool,
+  }
+  static defaultProps = {
+    from: {},
+    to: {},
+    config: config.default,
+    native: false,
+    immediate: false,
+  }
 }
 ```
 
@@ -56,35 +68,59 @@ import { Transition } from 'react-spring'
 
 ```jsx
 class Transition extends React.PureComponent {
-    static propTypes = {
-        native: PropTypes.bool,
-        config: PropTypes.object,
-        // Base styles
-        from: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
-        // Animated styles when the component is mounted
-        enter: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
-        // Unmpount styles
-        leave: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
-        //
-        update: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
-        // A collectiomn of unique keys that must match with the childrens order
-        // Can be omitted if children/render aren't an array
-        // Can be a function, which then acts as a key-accessor which is useful when you use the items prop
-        keys: PropTypes.oneOfType([
-            PropTypes.func,
-            PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
-            PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-        ]),
-        // Optional. Let items refer to the actual data and from/enter/leaver/update can return per-object styles
-        items: PropTypes.oneOfType([
-            PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.object])),
-            PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.object]),
-        ]),
-        children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.func), PropTypes.func]),
-        render: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.func), PropTypes.func]),
-    }
+  static propTypes = {
+    native: PropTypes.bool,
+    config: PropTypes.object,
+    // Base styles
+    from: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+    // Animated styles when the component is mounted
+    enter: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+    // Unmpount styles
+    leave: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+    //
+    update: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+    // A collectiomn of unique keys that must match with the childrens order
+    // Can be omitted if children/render aren't an array
+    // Can be a function, which then acts as a key-accessor which is useful when you use the items prop
+    keys: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.arrayOf(
+        PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+      ),
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    ]),
+    // Optional. Let items refer to the actual data and from/enter/leaver/update can return per-object styles
+    items: PropTypes.oneOfType([
+      PropTypes.arrayOf(
+        PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.number,
+          PropTypes.object,
+        ])
+      ),
+      PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number,
+        PropTypes.object,
+      ]),
+    ]),
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.func),
+      PropTypes.func,
+    ]),
+    render: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.func),
+      PropTypes.func,
+    ]),
+  }
 
-    static defaultProps = { from: {}, enter: {}, leave: {}, native: false, config: config.default }
+  static defaultProps = {
+    from: {},
+    enter: {},
+    leave: {},
+    native: false,
+    config: config.default,
+  }
 }
 ```
 
@@ -96,57 +132,72 @@ import { Trail } from 'react-spring'
 
 ```jsx
 class Trail extends React.PureComponent {
-    static propTypes = {
-        native: PropTypes.bool,
-        config: PropTypes.object,
-        from: PropTypes.object,
-        to: PropTypes.object,
-        keys: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.number])),
-        children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.func), PropTypes.func]),
-        render: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.func), PropTypes.func]),
-    }
-    static defaultProps = { from: {}, to: {}, native: false, config: config.default }
+  static propTypes = {
+    native: PropTypes.bool,
+    config: PropTypes.object,
+    from: PropTypes.object,
+    to: PropTypes.object,
+    keys: PropTypes.arrayOf(
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+    ),
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.func),
+      PropTypes.func,
+    ]),
+    render: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.func),
+      PropTypes.func,
+    ]),
+  }
+  static defaultProps = {
+    from: {},
+    to: {},
+    native: false,
+    config: config.default,
+  }
 }
 ```
 
 # Parallax
 
 ```jsx
-import { Parallax } from 'react-spring'
+import { Parallax, ParallaxLayer } from 'react-spring'
 ```
 
 ```jsx
 class Parallax extends React.PureComponent {
-    static propTypes = {
-        // Total (inner) height/width of the scroll container
-        pages: PropTypes.number.isRequired,
-        config: PropTypes.object,
-        // Has a scrollbar or doesn't ...
-        scrolling: PropTypes.bool,
-        // Scroll horizontally or vertically
-        horizontal: PropTypes.bool,
-    }
-    static defaultProps = {
-        config: config.slow,
-        scrolling: true,
-        horizontal: false,
-    }
+  static propTypes = {
+    // Total (inner) height/width of the scroll container
+    pages: PropTypes.number.isRequired,
+    config: PropTypes.object,
+    // Has a scrollbar or doesn't ...
+    scrolling: PropTypes.bool,
+    // Scroll horizontally or vertically
+    horizontal: PropTypes.bool,
+  }
 
-    static Layer = class extends React.PureComponent {
-        static propTypes = {
-            // Size of a page, by default 1
-            factor: PropTypes.number,
-            // Where the layer will be projected to (0=start, 1=first page, ...)
-            offset: PropTypes.number,
-            // Speed (and direction) it scrolls there, can be positive or negative
-            speed: PropTypes.number,
-        }
-        static defaultProps = {
-            factor: 1,
-            offset: 0,
-            speed: 0,
-        }
-    }
+  static defaultProps = {
+    config: config.slow,
+    scrolling: true,
+    horizontal: false,
+  }
+}
+
+class ParallaxLayer extends React.PureComponent {
+  static propTypes = {
+    // Size of a page, by default 1
+    factor: PropTypes.number,
+    // Where the layer will be projected to (0=start, 1=first page, ...)
+    offset: PropTypes.number,
+    // Speed (and direction) it scrolls there, can be positive or negative
+    speed: PropTypes.number,
+  }
+
+  static defaultProps = {
+    factor: 1,
+    offset: 0,
+    speed: 0,
+  }
 }
 ```
 
@@ -154,12 +205,12 @@ class Parallax extends React.PureComponent {
 
 ```jsx
 export default class Keyframes extends React.Component {
-    static propTypes = {
-        // Callback which receives a function that that takes two arguments:
-        //     script={async next => {
-        //         next(primitive, props)
-        //     }}
-        script: PropTypes.func,
-    }
+  static propTypes = {
+    // Callback which receives a function that that takes two arguments:
+    //     script={async next => {
+    //         next(primitive, props)
+    //     }}
+    script: PropTypes.func,
+  }
 }
 ```

--- a/examples/demos/areas/index.js
+++ b/examples/demos/areas/index.js
@@ -47,7 +47,7 @@ const Graph = ({ interpolate, data, xScale, yScale }) => (
   />
 )
 
-export default class extends React.Component {
+export default class AreasExample extends React.Component {
   state = { toggle: true }
   toggle = () => this.setState(state => ({ toggle: !state.toggle }))
   render() {

--- a/examples/demos/gestures/index.js
+++ b/examples/demos/gestures/index.js
@@ -7,7 +7,7 @@ import clamp from 'clamp'
 import './styles.css'
 
 @withGesture // https://github.com/drcmda/react-with-gesture
-export default class extends React.Component {
+export default class GesturesExample extends React.Component {
   render() {
     const { xDelta, down, children } = this.props
     const to = {

--- a/examples/demos/morph/index.js
+++ b/examples/demos/morph/index.js
@@ -13,7 +13,7 @@ const paths = [
 
 let current = paths[0]
 
-export default class extends React.Component {
+export default class MorphExample extends React.Component {
   state = { path: 0 }
   toggle = () => {
     let path = this.state.path + 1

--- a/examples/demos/nativespring/index.js
+++ b/examples/demos/nativespring/index.js
@@ -35,7 +35,7 @@ const Content = ({ toggle, backgroundColor, fill, rotate, scale, shape }) => (
   </animated.div>
 )
 
-export default class extends React.Component {
+export default class NativeSpringExample extends React.Component {
   state = { toggle: true }
   toggle = () => this.setState(state => ({ toggle: !state.toggle }))
   render() {

--- a/examples/demos/parallax/index.js
+++ b/examples/demos/parallax/index.js
@@ -2,31 +2,31 @@
 // https://dribbble.com/shots/4138489-Screeners
 
 import React from 'react'
-import { Parallax } from 'react-spring'
+import { Parallax, ParallaxLayer } from 'react-spring'
 import './styles.css'
 
 const Page = ({ offset, caption, first, second, gradient, onClick }) => (
   <React.Fragment>
-    <Parallax.Layer offset={offset} speed={0.2} onClick={onClick}>
+    <ParallaxLayer offset={offset} speed={0.2} onClick={onClick}>
       <div className="slopeBegin" />
-    </Parallax.Layer>
+    </ParallaxLayer>
 
-    <Parallax.Layer offset={offset} speed={-0.2} onClick={onClick}>
+    <ParallaxLayer offset={offset} speed={-0.2} onClick={onClick}>
       <div className={`slopeEnd ${gradient}`} />
-    </Parallax.Layer>
+    </ParallaxLayer>
 
-    <Parallax.Layer className="text number" offset={offset} speed={0.3}>
+    <ParallaxLayer className="text number" offset={offset} speed={0.3}>
       <span>0{offset + 1}</span>
-    </Parallax.Layer>
+    </ParallaxLayer>
 
-    <Parallax.Layer className="text header" offset={offset} speed={0.4}>
+    <ParallaxLayer className="text header" offset={offset} speed={0.4}>
       <span>
         <p style={{ fontSize: 20 }}>{caption}</p>
         <div className={`stripe ${gradient}`} />
         <p>{first}</p>
         <p>{second}</p>
       </span>
-    </Parallax.Layer>
+    </ParallaxLayer>
   </React.Fragment>
 )
 

--- a/examples/demos/reveals/index.js
+++ b/examples/demos/reveals/index.js
@@ -30,7 +30,7 @@ const B = styles => (
   </animated.div>
 )
 
-export default class extends React.PureComponent {
+export default class RevealsExample extends React.PureComponent {
   state = { toggled: true }
   toggle = e => this.setState(state => ({ toggled: !state.toggled }))
   render() {

--- a/examples/demos/scroll/index.js
+++ b/examples/demos/scroll/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Parallax } from 'react-spring'
+import { Parallax, ParallaxLayer } from 'react-spring'
 
 // Little helpers ...
 const url = (name, wrap = false) =>
@@ -27,23 +27,23 @@ const Gray = ({ children }) => (
   <span style={{ color: '#909090' }}>{children}</span>
 )
 
-export default class extends React.Component {
+export default class ScrollExample extends React.Component {
   render() {
     return (
       <div style={{ background: '#253237' }}>
         <Parallax ref={ref => (this.parallax = ref)} pages={3}>
-          <Parallax.Layer
+          <ParallaxLayer
             offset={1}
             speed={1}
             style={{ backgroundColor: '#805E73' }}
           />
-          <Parallax.Layer
+          <ParallaxLayer
             offset={2}
             speed={1}
             style={{ backgroundColor: '#87BCDE' }}
           />
 
-          <Parallax.Layer
+          <ParallaxLayer
             offset={0}
             speed={0}
             factor={3}
@@ -53,7 +53,7 @@ export default class extends React.Component {
             }}
           />
 
-          <Parallax.Layer
+          <ParallaxLayer
             offset={1.3}
             speed={-0.3}
             style={{ pointerEvents: 'none' }}
@@ -62,9 +62,9 @@ export default class extends React.Component {
               src={url('satellite4')}
               style={{ width: '15%', marginLeft: '70%' }}
             />
-          </Parallax.Layer>
+          </ParallaxLayer>
 
-          <Parallax.Layer offset={1} speed={0.8} style={{ opacity: 0.1 }}>
+          <ParallaxLayer offset={1} speed={0.8} style={{ opacity: 0.1 }}>
             <img
               src={url('cloud')}
               style={{ display: 'block', width: '20%', marginLeft: '55%' }}
@@ -73,9 +73,9 @@ export default class extends React.Component {
               src={url('cloud')}
               style={{ display: 'block', width: '10%', marginLeft: '15%' }}
             />
-          </Parallax.Layer>
+          </ParallaxLayer>
 
-          <Parallax.Layer offset={1.75} speed={0.5} style={{ opacity: 0.1 }}>
+          <ParallaxLayer offset={1.75} speed={0.5} style={{ opacity: 0.1 }}>
             <img
               src={url('cloud')}
               style={{ display: 'block', width: '20%', marginLeft: '70%' }}
@@ -84,9 +84,9 @@ export default class extends React.Component {
               src={url('cloud')}
               style={{ display: 'block', width: '20%', marginLeft: '40%' }}
             />
-          </Parallax.Layer>
+          </ParallaxLayer>
 
-          <Parallax.Layer offset={1} speed={0.2} style={{ opacity: 0.2 }}>
+          <ParallaxLayer offset={1} speed={0.2} style={{ opacity: 0.2 }}>
             <img
               src={url('cloud')}
               style={{ display: 'block', width: '10%', marginLeft: '10%' }}
@@ -95,9 +95,9 @@ export default class extends React.Component {
               src={url('cloud')}
               style={{ display: 'block', width: '20%', marginLeft: '75%' }}
             />
-          </Parallax.Layer>
+          </ParallaxLayer>
 
-          <Parallax.Layer offset={1.6} speed={-0.1} style={{ opacity: 0.4 }}>
+          <ParallaxLayer offset={1.6} speed={-0.1} style={{ opacity: 0.4 }}>
             <img
               src={url('cloud')}
               style={{ display: 'block', width: '20%', marginLeft: '60%' }}
@@ -110,9 +110,9 @@ export default class extends React.Component {
               src={url('cloud')}
               style={{ display: 'block', width: '10%', marginLeft: '80%' }}
             />
-          </Parallax.Layer>
+          </ParallaxLayer>
 
-          <Parallax.Layer offset={2.6} speed={0.4} style={{ opacity: 0.6 }}>
+          <ParallaxLayer offset={2.6} speed={0.4} style={{ opacity: 0.6 }}>
             <img
               src={url('cloud')}
               style={{ display: 'block', width: '20%', marginLeft: '5%' }}
@@ -121,9 +121,9 @@ export default class extends React.Component {
               src={url('cloud')}
               style={{ display: 'block', width: '15%', marginLeft: '75%' }}
             />
-          </Parallax.Layer>
+          </ParallaxLayer>
 
-          <Parallax.Layer
+          <ParallaxLayer
             offset={2.5}
             speed={-0.4}
             style={{
@@ -134,9 +134,9 @@ export default class extends React.Component {
             }}
           >
             <img src={url('earth')} style={{ width: '60%' }} />
-          </Parallax.Layer>
+          </ParallaxLayer>
 
-          <Parallax.Layer
+          <ParallaxLayer
             offset={2}
             speed={-0.3}
             style={{
@@ -146,7 +146,7 @@ export default class extends React.Component {
             }}
           />
 
-          <Parallax.Layer
+          <ParallaxLayer
             offset={0}
             speed={0.1}
             onClick={() => this.parallax.scrollTo(1)}
@@ -157,9 +157,9 @@ export default class extends React.Component {
             }}
           >
             <img src={url('server')} style={{ width: '20%' }} />
-          </Parallax.Layer>
+          </ParallaxLayer>
 
-          <Parallax.Layer
+          <ParallaxLayer
             offset={1}
             speed={0.1}
             onClick={() => this.parallax.scrollTo(2)}
@@ -170,9 +170,9 @@ export default class extends React.Component {
             }}
           >
             <img src={url('bash')} style={{ width: '40%' }} />
-          </Parallax.Layer>
+          </ParallaxLayer>
 
-          <Parallax.Layer
+          <ParallaxLayer
             offset={2}
             speed={-0}
             style={{
@@ -183,7 +183,7 @@ export default class extends React.Component {
             onClick={() => this.parallax.scrollTo(0)}
           >
             <img src={url('clients-main')} style={{ width: '40%' }} />
-          </Parallax.Layer>
+          </ParallaxLayer>
         </Parallax>
       </div>
     )

--- a/examples/demos/spring/index.js
+++ b/examples/demos/spring/index.js
@@ -50,7 +50,7 @@ const Content = ({
   </div>
 )
 
-export default class extends React.Component {
+export default class SpringExample extends React.Component {
   state = { toggle: true }
   toggle = () => this.setState(state => ({ toggle: !state.toggle }))
   render() {

--- a/examples/demos/sunburst/index.js
+++ b/examples/demos/sunburst/index.js
@@ -106,7 +106,7 @@ class Example extends React.Component {
 }
 
 const root = hierarchy(data).sum(d => d.size)
-const App = () => (
+const SunburstExample = () => (
   <ParentSize>
     {size =>
       size.ref && (
@@ -122,4 +122,4 @@ const App = () => (
   </ParentSize>
 )
 
-export default App
+export default SunburstExample

--- a/examples/demos/timing/index.js
+++ b/examples/demos/timing/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Spring, Keyframes, animated } from 'react-spring'
 import { TimingAnimation, Easing } from '../../../src/addons'
 
-export default class App extends React.PureComponent {
+export default class TimingExample extends React.PureComponent {
   state = { items: ['item1', 'item2', 'item3'] }
 
   render() {

--- a/examples/demos/trails/index.js
+++ b/examples/demos/trails/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Trail, animated } from 'react-spring'
 import './styles.css'
 
-export default class extends React.PureComponent {
+export default class TrailsExample extends React.PureComponent {
   state = { toggle: true, items: ['item1', 'item2', 'item3', 'item4', 'item5'] }
   toggle = () => this.setState(state => ({ toggle: !state.toggle }))
   render() {

--- a/examples/demos/transitions/index.js
+++ b/examples/demos/transitions/index.js
@@ -13,7 +13,7 @@ const defaultStyles = {
   textTransform: 'uppercase',
 }
 
-export default class extends React.PureComponent {
+export default class TransitionsExample extends React.PureComponent {
   state = { items: [] }
 
   componentDidMount() {

--- a/examples/demos/tree/index.js
+++ b/examples/demos/tree/index.js
@@ -3,7 +3,7 @@ import { ParentSize } from '@vx/responsive'
 import Tree from './Tree'
 import data from './data'
 
-const App = () => (
+const TreeExample = () => (
   <ParentSize>
     {size =>
       size.ref && (
@@ -27,4 +27,4 @@ const App = () => (
   </ParentSize>
 )
 
-export default App
+export default TreeExample

--- a/readme.md
+++ b/readme.md
@@ -6,43 +6,43 @@
 
 # Table of Contents 👇
 
-*   [What is it?](#what-is-it-)
-*   [Why do we need yet another?](#why-do-we-need-yet-another-)
-*   [Overview](#overview-)
-*   [Example collection](#example-collection-)
-*   [API Overview](#api-overview-)
-    *   [Springs and basic interpolation](#springs-and-basic-interpolation)
-    *   [Render props](#render-props)
-    *   [Native rendering and interpolation](#native-rendering-and-interpolation-demo)
-    *   [Transitions](#transitions)
-    *   [Parallax and page transitions](#parallax-and-page-transitions)
+* [What is it?](#what-is-it-)
+* [Why do we need yet another?](#why-do-we-need-yet-another-)
+* [Overview](#overview-)
+* [Example collection](#example-collection-)
+* [API Overview](#api-overview-)
+  * [Springs and basic interpolation](#springs-and-basic-interpolation)
+  * [Render props](#render-props)
+  * [Native rendering and interpolation](#native-rendering-and-interpolation-demo)
+  * [Transitions](#transitions)
+  * [Parallax and page transitions](#parallax-and-page-transitions)
 
 # What is it? 🤔
 
 <p align="middle">
   <img src="assets/spring.gif" width="285" />
-  <img src="assets/transitions.gif" width="285" /> 
-  <img src="assets/trails.gif" width="285" /> 
+  <img src="assets/transitions.gif" width="285" />
+  <img src="assets/trails.gif" width="285" />
 </p>
 <p align="middle">
   <img src="assets/tree.gif" width="285" />
-  <img src="assets/sunburst.gif" width="285" /> 
-  <img src="assets/areas.gif" width="285" /> 
+  <img src="assets/sunburst.gif" width="285" />
+  <img src="assets/areas.gif" width="285" />
 </p>
 <p align="middle">
   <img src="assets/gestures.gif" width="285" />
-  <img src="assets/reveals.gif" width="285" /> 
-  <img src="assets/morph.gif" width="285" /> 
+  <img src="assets/reveals.gif" width="285" />
+  <img src="assets/morph.gif" width="285" />
 </p>
 <p align="middle">
   <img src="assets/vertical.gif" width="285" />
-  <img src="assets/horizontal.gif" width="285" /> 
-  <img src="assets/keyframes-trail.gif" width="285" /> 
+  <img src="assets/horizontal.gif" width="285" />
+  <img src="assets/keyframes-trail.gif" width="285" />
 </p>
 <p align="middle">
   <img src="assets/dragndrop.gif" width="285" />
-  <img src="assets/stream.gif" width="285" /> 
-  <img src="assets/time.gif" width="285" /> 
+  <img src="assets/stream.gif" width="285" />
+  <img src="assets/time.gif" width="285" />
 </p>
 
 A set of simple, spring-physics based primitives (as in building blocks) that should cover most of your UI related animation needs once plain CSS can't cope any longer. Forget easings, durations, timeouts and so on as you fluidly move data from one state to another. This isn't meant to solve each and every problem but rather to give you tools flexible enough to confidently cast ideas into moving interfaces.
@@ -130,15 +130,15 @@ import { Trail } from 'react-spring'
 `Parallax` allows you to declaratively create page/scroll-based animations.
 
 ```jsx
-import { Parallax } from 'react-spring'
+import { Parallax, ParallaxLayer } from 'react-spring'
 
 <Parallax pages={2}>
-    <Parallax.Layer offset={0} speed={0.2}>
+    <ParallaxLayer offset={0} speed={0.2}>
         first Page
-    </Parallax.Layer>
-    <Parallax.Layer offset={1} speed={0.5}>
+    </ParallaxLayer>
+    <ParallaxLayer offset={1} speed={0.5}>
         second Page
-    </Parallax.Layer>
+    </ParallaxLayer>
 </Parallax>
 ```
 
@@ -235,9 +235,9 @@ Et voilà! `Header` animates on prop changes! Props that `Spring` doesn't recogn
 
 ### Native rendering and interpolation ([Demo](https://codesandbox.io/embed/882njxpz29))
 
-![img](assets/without-native.jpeg) | ![img](assets/with-native.jpeg)
----|---
-<sub>Libraries animate by having React recalculate the component-tree on every frame. Here it attempts to animate a component consisting of ~300 sub-components, plowing through the frame budget and causing jank.</sub> | <sub>React-spring with the `native` property renders the component *only once*, from then on the animation will be applied directly to the dom in a requestAnimationFrame-loop, similar to how gsap and d3 do it.</sub>
+| ![img](assets/without-native.jpeg)                                                                                                                                                                                        | ![img](assets/with-native.jpeg)                                                                                                                                                                                         |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <sub>Libraries animate by having React recalculate the component-tree on every frame. Here it attempts to animate a component consisting of ~300 sub-components, plowing through the frame budget and causing jank.</sub> | <sub>React-spring with the `native` property renders the component _only once_, from then on the animation will be applied directly to the dom in a requestAnimationFrame-loop, similar to how gsap and d3 do it.</sub> |
 
 ---
 
@@ -255,7 +255,7 @@ import { Spring, animated, interpolate } from 'react-spring'
 
 <Spring native from={{ radius: 0, time: 0, x: 0, y: 0 }} to={{ radius: 10, time: 1, x: 10, y: 20 }}>
     {({ radius, time, x, y }) => (
-        <animated.div 
+        <animated.div
             style={{
                 // Use plain animated values like always, ...
                 borderRadius: radius,
@@ -293,7 +293,7 @@ You can use this prototype for two-state reveals, simply render a single child t
 
 ```jsx
 <Transition from={{ opacity: 0 }} enter={{ opacity: 1 }} leave={{ opacity: 0 }}>
-    {toggle ? ComponentA : ComponentB}
+  {toggle ? ComponentA : ComponentB}
 </Transition>
 ```
 
@@ -301,13 +301,14 @@ For more complex animations you can return per-object styles individually. Let T
 
 ```jsx
 <Transition
-    items={items}
-    keys={item => item.key}
-    from={item => ({ opacity: 0 })}
-    enter={item => ({ opacity: 1 })}
-    update={item => ({ opacity: 0.5 })}
-    leave={item => ({ opacity: 0 })}>
-    {items.map(item => styles => <li style={styles}>{item.text}</li>)}
+  items={items}
+  keys={item => item.key}
+  from={item => ({ opacity: 0 })}
+  enter={item => ({ opacity: 1 })}
+  update={item => ({ opacity: 0.5 })}
+  leave={item => ({ opacity: 0 })}
+>
+  {items.map(item => styles => <li style={styles}>{item.text}</li>)}
 </Transition>
 ```
 
@@ -327,17 +328,17 @@ import { Trail } from 'react-spring'
 
 `Parallax` creates a scroll container. Throw in any amount of layers and it will take care of moving them in accordance to their offsets and speeds.
 
-`Parallax.pages` determines the total space of the inner content where each page takes 100% of the visible container. `Layer.offset` determines where the layer will be at when scrolled to (0=start, 1=1st page, ...). `Layer.speed` shifts the layer in accordance to its offset, values can be positive or negative.
+`Parallax.pages` determines the total space of the inner content where each page takes 100% of the visible container. `ParallaxLayer.offset` determines where the layer will be at when scrolled to (0=start, 1=1st page, ...). `ParallaxLayer.speed` shifts the layer in accordance to its offset, values can be positive or negative.
 
 ```jsx
-import { Parallax } from 'react-spring'
+import { Parallax, ParallaxLayer } from 'react-spring'
 
 <Parallax pages={3} scrolling={false} horizontal ref={ref => this.parallax = ref}>
-    <Parallax.Layer offset={0} speed={0.5}>
+    <ParallaxLayer offset={0} speed={0.5}>
         <span onClick={() => this.parallax.scrollTo(1)}>
             Layers can contain anything
         </span>
-    </Parallax.Layer>
+    </ParallaxLayer>
 </Parallax>
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import Value from './animated/AnimatedValue'
 import Spring, { config, template, animated, interpolate } from './Spring'
 import Transition from './Transition'
 import Trail from './Trail'
-import Parallax from './Parallax'
+import Parallax, { ParallaxLayer } from './Parallax'
 import Keyframes from './Keyframes'
 
 export {
@@ -12,6 +12,7 @@ export {
   Transition,
   Trail,
   Parallax,
+  ParallaxLayer,
   config,
   template,
   animated,


### PR DESCRIPTION
This pattern looks good, but it fails if we need to achieve treeshaking.

I converted docs and examples to this way
```js
import { Parallax, ParallaxLayer } from 'react-spring'
```
but still keep `Parallax.Layer` for backward compatibility.