### PR TITLE
Inline default props to enable treeshaking for Transition component

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,17 +1,17 @@
 {
   "dist/react-spring.es.js": {
-    "bundled": 65015,
-    "minified": 30459,
-    "gzipped": 8712,
+    "bundled": 65434,
+    "minified": 30507,
+    "gzipped": 8744,
     "treeshaked": {
-      "rollup": 25651,
-      "webpack": 26635
+      "rollup": 23047,
+      "webpack": 24019
     }
   },
   "dist/react-spring.umd.js": {
-    "bundled": 86487,
-    "minified": 37632,
-    "gzipped": 12509
+    "bundled": 86906,
+    "minified": 37688,
+    "gzipped": 12536
   },
   "dist/addons.js": {
     "bundled": 14595,

--- a/src/Transition.js
+++ b/src/Transition.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Animated from './animated/targets/react-dom'
-import Spring, { config } from './Spring'
+import Spring, { config as springConfig } from './Spring'
 
 const ref = (object, key) =>
   typeof object === 'function' ? object(key) : object
@@ -51,17 +51,18 @@ export default class Transition extends React.Component {
     ]),
   }
 
-  static defaultProps = {
-    from: {},
-    enter: {},
-    leave: {},
-    native: false,
-    config: config.default,
-  }
-
   constructor(props) {
     super()
-    let { children, render, keys, items, from, enter, leave, update } = props
+    let {
+      children,
+      render,
+      keys,
+      items,
+      from = {},
+      enter = {},
+      leave = {},
+      update,
+    } = props
     children = render || children || (() => null)
     if (typeof keys === 'function') keys = items.map(keys)
     if (!Array.isArray(children)) {
@@ -90,7 +91,16 @@ export default class Transition extends React.Component {
 
   componentWillReceiveProps(props) {
     let { transitions, transitionKeys } = this.state
-    let { children, render, keys, items, from, enter, leave, update } = props
+    let {
+      children,
+      render,
+      keys,
+      items,
+      from = {},
+      enter = {},
+      leave = {},
+      update,
+    } = props
 
     children = render || children || (() => null)
     if (typeof keys === 'function') keys = items.map(keys)
@@ -192,11 +202,11 @@ export default class Transition extends React.Component {
   render() {
     const {
       render,
-      from,
-      enter,
-      leave,
-      native,
-      config,
+      from = {},
+      enter = {},
+      leave = {},
+      native = false,
+      config = springConfig.default,
       keys,
       items,
       onFrame,


### PR DESCRIPTION
With this change we achieve 2.5 kb better treeshaking.