### PR TITLE
Allow passing animated values to Spring, add hold prop

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,17 +1,17 @@
 {
   "dist/react-spring.es.js": {
-    "bundled": 74561,
-    "minified": 36028,
-    "gzipped": 11250,
+    "bundled": 74934,
+    "minified": 36178,
+    "gzipped": 11296,
     "treeshaked": {
-      "rollup": 28319,
-      "webpack": 29327
+      "rollup": 28457,
+      "webpack": 29465
     }
   },
   "dist/react-spring.umd.js": {
-    "bundled": 87866,
-    "minified": 38098,
-    "gzipped": 12704
+    "bundled": 88349,
+    "minified": 38236,
+    "gzipped": 12754
   },
   "dist/NumericalSpring.cjs.js": {
     "bundled": 33038,


### PR DESCRIPTION
My use case is horizontal panning using native rendering.

In the [horizontal gesture example](https://codesandbox.io/embed/jzn14k0ppy) `xDelta` is passed to `Spring`, which means every pointer move event causes a render.

This pull request allows passing an `Animated.Value` into `Spring` such that it may be manipulated outside of the render function, and also adds a `hold` prop which works like `immediate` except it makes the given animations not start.

I used this to update the animated value on pointer move events, and hold the animation for as long as the interaction lasts.

Example:

```
import { Spring, Value, animated, interpolate } from "react-spring";

class Swipe extends Component {
  state = {
    value: new Value(25),
    wait: true
  };

  componentDidMount() {
    setTimeout(() => this.state.value.setValue(50), 1000);
    setTimeout(() => this.setState({ wait: false }), 2000);
  }

  render() {
    const { value, wait } = this.state;

    const from = { offset: value };
    const to = { offset: 0 };
    const hold = wait && ["offset"];

    return (
      <Spring native from={from} to={to} hold={hold}>
        {({ offset }) => (
          <animated.div
            style={{
              transform: offset.interpolate(x => `translate3d(${x}%,0,0)`)
            }}
          >
            test
          </animated.div>
        )}
      </Spring>
    );
  }
}
```

What are your thoughts on this, both idea and API? Is there a better way to achieve native rendering on gesture animations?