### PR TITLE
Use createPortal in fix-auto to preserve context for child components

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,17 +1,17 @@
 {
   "dist/react-spring.es.js": {
-    "bundled": 67719,
-    "minified": 31289,
-    "gzipped": 9025,
+    "bundled": 75826,
+    "minified": 36798,
+    "gzipped": 11444,
     "treeshaked": {
-      "rollup": 23082,
-      "webpack": 24107
+      "rollup": 28082,
+      "webpack": 29083
     }
   },
   "dist/react-spring.umd.js": {
-    "bundled": 750483,
-    "minified": 295837,
-    "gzipped": 93007
+    "bundled": 750195,
+    "minified": 296062,
+    "gzipped": 93180
   },
   "dist/addons.js": {
     "bundled": 14595,

--- a/src/animated/targets/react-dom/fix-auto.js
+++ b/src/animated/targets/react-dom/fix-auto.js
@@ -31,7 +31,7 @@ export default function fixAuto(spring, props) {
       : { ...from, ...to, ...forward }
 
     // Render to-state vdom to portal
-    ReactDOM.render(
+    ReactDOM.createPortal(
       <div
         ref={ref => {
           if (ref) {


### PR DESCRIPTION
Possible fix for https://github.com/drcmda/react-spring/issues/52