### PR TITLE
[docs] fixed two links

### DIFF
--- a/API-OVERVIEW.md
+++ b/API-OVERVIEW.md
@@ -3,7 +3,7 @@
 
 * [Springs and basic interpolation](#springs-and-basic-interpolation)
 * [Render props](#render-props)
-* [Native rendering and interpolation](#native-rendering-and-interpolation)
+* [Native rendering and interpolation](#native-rendering-and-interpolation-demo)
 * [Imperative Api](#imperative-api)
 * [Transitions](#transitions)
 * [Parallax and page transitions](#parallax-and-page-transitions)
@@ -98,7 +98,7 @@ const App = ({ children }) => {
   const hover = () => spring(animation, { to: '#c23369' }).start()
   const unhover = () => spring(animation, { to: '#28d79f' }).start()
   return (
-    <animated.div 
+    <animated.div
       style={{ background: animation }}
       onMouseOver={hover}
       onMouseOut={unhover} />

--- a/readme.md
+++ b/readme.md
@@ -219,7 +219,7 @@ import { Spring, animated } from 'react-spring'
 </Spring>
 ```
 
-More about native rendering and interpolation [here](https://github.com/drcmda/react-spring/edit/master/API-OVERVIEW.md#native-rendering-and-interpolation).
+More about native rendering and interpolation [here](https://github.com/drcmda/react-spring/blob/master/API-OVERVIEW.md#native-rendering-and-interpolation-demo).
 
 # Links 🔗
 


### PR DESCRIPTION
Small fix for two links in the documentation.  Also, capitalized README.md since all the other docs were capitalized.  

---

One quick question with the docs.  I was reading up on the native and animated component.  The usage suggests `animated.div` and I noticed it works with other html elements like `animated.li`.  

I tried to get it to work with a react component `const MyDiv = props => <div>{props.children}</div>
`, but `animated.MyDiv` didn’t work.  ([https://codesandbox.io/s/l419mkpn69](https://codesandbox.io/s/l419mkpn69))  

I assume I cannot use animated with functional or class components?