### PR TITLE
Move fix-auto from portal-based to in-place hidden measuring

### DIFF
--- a/src/animated/targets/react-dom/fix-auto.js
+++ b/src/animated/targets/react-dom/fix-auto.js
@@ -29,6 +29,7 @@ export default function fixAuto(spring, props) {
 
   return (
     <div
+      style={{ visibility: 'hidden', position: 'absolute' }}
       ref={ref => {
         if (ref) {
           // Once it's rendered out, fetch bounds

--- a/src/animated/targets/react-dom/fix-auto.js
+++ b/src/animated/targets/react-dom/fix-auto.js
@@ -27,18 +27,12 @@ export default function fixAuto(spring, props) {
     ? allProps.reduce(convert, forward)
     : { ...from, ...to, ...forward }
 
-  // Setting height and scroll properties so that the measuring div will be
-  // invisible and avoid a flash of unmeasured content
-  const measuringDivStyle = { overflowY: 'auto', height: 0 };
-
   return (
     <div
-      style={measuringDivStyle}
       ref={ref => {
         if (ref) {
-          // Once it's rendered out, fetch bounds. Infer total content height
-          // from the available scroll height of the 0-sized measuring div
-          const height = ref.scrollHeight
+          // Once it's rendered out, fetch bounds
+          const height = ref.clientHeight
           const width = ref.clientWidth
 
           // Defer to next frame, or else the springs updateToken is canceled

--- a/src/animated/targets/react-dom/fix-auto.js
+++ b/src/animated/targets/react-dom/fix-auto.js
@@ -29,7 +29,6 @@ export default function fixAuto(spring, props) {
 
   return (
     <div
-      style={{ visibility: 'hidden', position: 'absolute' }}
       ref={ref => {
         if (ref) {
           // Once it's rendered out, fetch bounds

--- a/src/animated/targets/react-dom/fix-auto.js
+++ b/src/animated/targets/react-dom/fix-auto.js
@@ -21,26 +21,26 @@ export default function fixAuto(spring, props) {
 
   const forward = spring.getForwardProps(props)
   const allProps = Object.entries({ ...from, ...to })
-  const portal = document.createElement('div')
-  portal.style.cssText = 'position:static;visibility:hidden;'
-  document.body.appendChild(portal)
 
   // Collect to-state props
   const componentProps = native
     ? allProps.reduce(convert, forward)
     : { ...from, ...to, ...forward }
 
-  // Render to-state vdom to portal
-  return ReactDOM.createPortal(
+  // Setting height and scroll properties so that the measuring div will be
+  // invisible and avoid a flash of unmeasured content
+  const measuringDivStyle = { overflowY: 'auto', height: 0 };
+
+  return (
     <div
+      style={measuringDivStyle}
       ref={ref => {
         if (ref) {
-          // Once it's rendered out, fetch bounds
-          const height = ref.clientHeight
+          // Once it's rendered out, fetch bounds. Infer total content height
+          // from the available scroll height of the 0-sized measuring div
+          const height = ref.scrollHeight
           const width = ref.clientWidth
 
-          // Remove portal and resolve promise with updated props
-          document.body.removeChild(portal)
           // Defer to next frame, or else the springs updateToken is canceled
           requestAnimationFrame(() =>
             spring.updateProps(
@@ -58,7 +58,6 @@ export default function fixAuto(spring, props) {
         }
       }}>
       {children(componentProps)}
-    </div>,
-    portal
+    </div>
   )
 }


### PR DESCRIPTION
### Summary

The portal-based solution resulted in inaccurate width calculations on the user's content when the content did not have a constrained width value and contained wrapping text.

This solution uses a 0-height rendering of the user's content in-place, so that all layout constraints stay consistent with intended usage. I used a little trick to get the total height based on the `scrollHeight` on the 0-height measuring element.

I'm not convinced this will work with all layouts, since we're rendering this intermediate div, which breaks any layout properties which the user's content might be getting from its parent. Still, I think this solution may fit a wider variety of use cases than the current one.