### PR TITLE
🔥 Remove console log

### DIFF
--- a/src/Spring.js
+++ b/src/Spring.js
@@ -155,7 +155,6 @@ export default class Spring extends React.PureComponent {
           cb && typeof cb === 'function' && cb(current)
 
           if (didInject) {
-            console.log('inject done')
             // Restore the original values for injected props
             const componentProps = this.convertValues(this.props)
             this.inject = this.renderChildren(this.props, componentProps)


### PR DESCRIPTION
I've pulled down the latest of `react-spring@5.1.8` and started seeing "inject done" in the console. This PR removes that `console.log`.

BTW thanks for the great lib. 😄 