### PR TITLE
Remove trailing comma from Spring' generics

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -82,7 +82,7 @@ declare module 'react-spring' {
 
   export class Spring<
     S extends object,
-    DS extends object,
+    DS extends object
   > extends PureComponent<SpringProps<S, DS>> {}
 
   export function interpolate(


### PR DESCRIPTION
Apologies for the low effort contribution, if this gets accepted, there'll be more to follow, I promise!
I'm currently working on expanding the types (by declaring my own types for react-spring from within the project I'm currently working on), but I can't get TS to even use the existing definition, because it has a syntax error (TS1009).
I'm guessing this check has been added in a newer version of typescript? (see prettier/prettier#1820 for more info).