### PR TITLE
Fix typo in the typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -133,7 +133,7 @@ declare module 'react-spring' {
      * Can be a function, which then acts as a key-accessor which is useful when you use the items prop
      * @default {}
      */
-    keys: ((params: any) => TransitionKeyProps) | Array<TransitionKeyProps> | TransitionKeyProps;
+    keys?: ((params: any) => TransitionKeyProps) | Array<TransitionKeyProps> | TransitionKeyProps;
     /**
      * Optional. Let items refer to the actual data and from/enter/leaver/update can return per-object styles
      * @default {}


### PR DESCRIPTION
A typo in typings was fixed, due to which sometimes the Transition component could not be used.