### PR TITLE
Improve the Spring API docs

### DIFF
--- a/API.md
+++ b/API.md
@@ -18,6 +18,8 @@ import { config } from 'react-spring'
 
 - tension, controls the initial plus force of the spring when let loose (default: 170)
 - friction, controls the opposition or antagonistic minus force (default: 26)
+- velocity, controls the initial velocity of the object attached to the spring (default: 0)
+- overshootClamping, controls if the spring should be clamped and not bounce (default: false)
 - restSpeedThreshold, precision (default: 0.0001)
 - restDisplacementThreshold, displacement precision (default: 0.0001)
 
@@ -51,9 +53,7 @@ class Spring extends React.PureComponent {
     immediate: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
     // Won't start animations, so they can be controlled from outside
     hold: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
-    // Spring configuration
-    // Can be a object with the fields tension, friction, velocity, overshootClamping, restDisplacementThreshold, and restSpeedThreshold
-    // Can be a function receiving a name
+    // Spring config ({ tension, friction, ... } or a function receiving a name)
     config: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     // Animation start delay, optional
     delay: PropTypes.number,

--- a/API.md
+++ b/API.md
@@ -51,8 +51,12 @@ class Spring extends React.PureComponent {
     immediate: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
     // Won't start animations, so they can be controlled from outside
     hold: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
-    // Spring config ({ tension, friction } or a function receiving a name)
+    // Spring configuration
+    // Can be a object with the fields tension, friction, velocity, overshootClamping, restDisplacementThreshold, and restSpeedThreshold
+    // Can be a function receiving a name
     config: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
+    // Animation start delay, optional
+    delay: PropTypes.number,
     // When true it literally resets: from -> to
     reset: PropTypes.bool,
   }
@@ -60,6 +64,7 @@ class Spring extends React.PureComponent {
     from: {},
     to: {},
     config: config.default,
+    delay: 0,
     native: false,
     immediate: false,
     hold: false,

--- a/API.md
+++ b/API.md
@@ -64,7 +64,6 @@ class Spring extends React.PureComponent {
     from: {},
     to: {},
     config: config.default,
-    delay: 0,
     native: false,
     immediate: false,
     hold: false,


### PR DESCRIPTION
This PR adds information on the docs about the full RK4 Algorithm support of the `Spring` component.

Note: I'm not sure if the `Transition` or another component needs to be updated, for now, I will just update the `Spring` docs.