### PR TITLE
Add SpringRendererFunc typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ declare module 'react-spring' {
 
   type SpringRendererFunc<S extends object, DS extends object = {}> = (
     params: DS & S
-  ) => ReactNode
+  ) => ReactNode;
 
   type SpringProps<S extends object, DS extends object = {}> = {
     /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -135,7 +135,7 @@ declare module 'react-spring' {
      * Can be a function, which then acts as a key-accessor which is useful when you use the items prop
      * @default {}
      */
-    keys?: ((params: any) => TransitionKeyProps) | Array<TransitionKeyProps> | TransitionKeyProps;
+    keys?: ((params: TransitionItemProps) => TransitionKeyProps) | Array<TransitionKeyProps> | TransitionKeyProps;
     /**
      * Optional. Let items refer to the actual data and from/enter/leaver/update can return per-object styles
      * @default {}

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,10 @@ declare module 'react-spring' {
     friction: number;
   };
 
+  type SpringRendererFunc<S extends object, DS extends object = {}> = (
+    params: DS & S
+  ) => ReactNode
+
   type SpringProps<S extends object, DS extends object = {}> = {
     /**
      * Spring config ({ tension, friction })
@@ -38,13 +42,11 @@ declare module 'react-spring' {
     /**
      * Takes a function that receives interpolated styles
      */
-    children?: ((
-      params: DS & S,
-    ) => ReactNode) | Array<(params: DS & S) => ReactNode>;
+    children?: SpringRendererFunc<S, DS> | Array<SpringRendererFunc<S, DS>>;
     /**
      * Same as children, but takes precedence if present
      */
-    render?: (params: DS & S) => ReactNode;
+    render?: SpringRendererFunc<S, DS>;
     /**
      * Prevents animation if true, you can also pass individual keys
      * @default false
@@ -140,13 +142,9 @@ declare module 'react-spring' {
      */
     items?: Array<TransitionItemProps> | TransitionItemProps;
 
-    children?: ((
-      params: DS & S,
-    ) => ReactNode) | Array<(params: DS & S) => ReactNode>;
+    children?: SpringRendererFunc<S, DS> | Array<SpringRendererFunc<S, DS>>;
 
-    render?: ((
-      params: DS & S,
-    ) => ReactNode) | Array<(params: DS & S) => ReactNode>;
+    render?: SpringRendererFunc<S, DS> | Array<SpringRendererFunc<S, DS>>;
   };
 
   export class Transition<
@@ -163,13 +161,9 @@ declare module 'react-spring' {
 
     to?: DS;
 
-    children: ((
-      params: DS & S,
-    ) => ReactNode) | Array<(params: DS & S) => ReactNode>;
+    children: SpringRendererFunc<S, DS> | Array<SpringRendererFunc<S, DS>>;
 
-    render: ((
-      params: DS & S,
-    ) => ReactNode) | Array<(params: DS & S) => ReactNode>;
+    render: SpringRendererFunc<S, DS> | Array<SpringRendererFunc<S, DS>>;
   };
 
   export class Trail<

--- a/index.d.ts
+++ b/index.d.ts
@@ -38,9 +38,9 @@ declare module 'react-spring' {
     /**
      * Takes a function that receives interpolated styles
      */
-    children?: (
+    children?: ((
       params: DS & S,
-    ) => ReactNode | Array<(params: DS & S) => ReactNode>;
+    ) => ReactNode) | Array<(params: DS & S) => ReactNode>;
     /**
      * Same as children, but takes precedence if present
      */
@@ -140,13 +140,13 @@ declare module 'react-spring' {
      */
     items?: Array<TransitionItemProps> | TransitionItemProps;
 
-    children?: (
+    children?: ((
       params: DS & S,
-    ) => ReactNode | Array<(params: DS & S) => ReactNode>;
+    ) => ReactNode) | Array<(params: DS & S) => ReactNode>;
 
-    render?: (
+    render?: ((
       params: DS & S,
-    ) => ReactNode | Array<(params: DS & S) => ReactNode>;
+    ) => ReactNode) | Array<(params: DS & S) => ReactNode>;
   };
 
   export class Transition<
@@ -163,13 +163,13 @@ declare module 'react-spring' {
 
     to?: DS;
 
-    children: (
+    children: ((
       params: DS & S,
-    ) => ReactNode | Array<(params: DS & S) => ReactNode>;
+    ) => ReactNode) | Array<(params: DS & S) => ReactNode>;
 
-    render: (
+    render: ((
       params: DS & S,
-    ) => ReactNode | Array<(params: DS & S) => ReactNode>;
+    ) => ReactNode) | Array<(params: DS & S) => ReactNode>;
   };
 
   export class Trail<


### PR DESCRIPTION
I recently encountered that TypeScript is throwing typing error when I use `<Transition />` because `children` type does not match.
When I inspected the typing file in the repo, I found out that the definition for `render` and `children` could cause some misunderstanding.

Therefore I offer a fix to this, take a look at the changes.