### PR TITLE
Fix keyframes types and use interface so user can extend

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,8 +1,8 @@
 {
   "dist/addons.umd.js": {
-    "bundled": 15720,
-    "minified": 5853,
-    "gzipped": 2141
+    "bundled": 16003,
+    "minified": 5898,
+    "gzipped": 2150
   },
   "dist/web.umd.js": {
     "bundled": 86586,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,228 +1,248 @@
-declare module 'react-spring' {
-  import { Component, PureComponent, ReactNode, ComponentClass } from 'react';
+import {
+  Component,
+  PureComponent,
+  ReactNode,
+  ComponentClass,
+  ComponentType,
+} from 'react'
 
-  export type SpringEasingFunc = (t: number) => number;
+export type SpringEasingFunc = (t: number) => number
 
-  export type SpringConfig = {
-    tension?: number;
-    friction?: number;
-    velocity?: number;
-    overshootClamping?: number;
-    restSpeedThreshold?: number;
-    restDisplacementThreshold?: number
+export interface SpringConfig {
+  tension?: number
+  friction?: number
+  velocity?: number
+  overshootClamping?: number
+  restSpeedThreshold?: number
+  restDisplacementThreshold?: number
 
-    duration?: number;
-    easing?: SpringEasingFunc;
-  };
+  duration?: number
+  easing?: SpringEasingFunc
+}
 
-  type SpringRendererFunc<S extends object, DS extends object = {}> = (
-    params: DS & S
-  ) => ReactNode;
+type SpringRendererFunc<S extends object, DS extends object = {}> = (
+  params: DS & S
+) => ReactNode
 
-  type SpringProps<S extends object, DS extends object = {}> = {
-    /**
-     * Spring config ({ tension, friction })
-     * @default config.default
-     */
-    config?: SpringConfig | ((key: string) => SpringConfig);
-    /**
-     * Will skip rendering the component if true and write to the dom directly
-     * @default false
-     */
-    native?: boolean;
-    /**
-     * Base styles
-     * @default {}
-     */
-    from?: DS;
-    /**
-     * Animates to...
-     * @default {}
-     */
-    to: DS;
-    /**
-     * Callback when the animation starts to animate
-     */
-    onStart?: () => void;
-    /**
-     * Callback when the animation comes to a still-stand
-     */
-    onRest?: () => void;
-    /**
-     * Frame by frame callback, first argument passed is the animated value
-     */
-    onFrame?: () => void;
-    /**
-     * Takes a function that receives interpolated styles
-     */
-    children?: SpringRendererFunc<S, DS> | Array<SpringRendererFunc<S, DS>>;
-    /**
-     * Same as children, but takes precedence if present
-     */
-    render?: SpringRendererFunc<S, DS>;
-    /**
-     * Prevents animation if true, you can also pass individual keys
-     * @default false
-     */
-    immediate?: boolean | string[] | ((key: string) => boolean);
-    /**
-     * When true it literally resets: from -> to
-     * @default false
-     */
-    reset?: boolean;
-    /**
-     * Animation implementation
-     * @default SpringAnimation
-     */
-    impl?: any,
-    /**
-     * Inject props
-     * @default undefined
-     */
-    inject?: any,
-  };
+interface SpringProps<S extends object, DS extends object = {}> {
+  /**
+   * Spring config ({ tension, friction })
+   * @default config.default
+   */
+  config?: SpringConfig | ((key: string) => SpringConfig)
+  /**
+   * Will skip rendering the component if true and write to the dom directly
+   * @default false
+   */
+  native?: boolean
+  /**
+   * Base styles
+   * @default {}
+   */
+  from?: DS
+  /**
+   * Animates to...
+   * @default {}
+   */
+  to: DS
+  /**
+   * Callback when the animation starts to animate
+   */
+  onStart?: () => void
+  /**
+   * Callback when the animation comes to a still-stand
+   */
+  onRest?: () => void
+  /**
+   * Frame by frame callback, first argument passed is the animated value
+   */
+  onFrame?: () => void
+  /**
+   * Takes a function that receives interpolated styles
+   */
+  children?: SpringRendererFunc<S, DS> | Array<SpringRendererFunc<S, DS>>
+  /**
+   * Same as children, but takes precedence if present
+   */
+  render?: SpringRendererFunc<S, DS>
+  /**
+   * Prevents animation if true, you can also pass individual keys
+   * @default false
+   */
+  immediate?: boolean | string[] | ((key: string) => boolean)
+  /**
+   * When true it literally resets: from -> to
+   * @default false
+   */
+  reset?: boolean
+  /**
+   * Animation implementation
+   * @default SpringAnimation
+   */
+  impl?: any
+  /**
+   * Inject props
+   * @default undefined
+   */
+  inject?: any
+}
 
-  export const config: {
-    /** default: { tension: 170, friction: 26 } */
-    default: SpringConfig;
-    /** gentle: { tension: 120, friction: 14 } */
-    gentle: SpringConfig;
-    /** wobbly: { tension: 180, friction: 12 } */
-    wobbly: SpringConfig;
-    /** stiff: { tension: 210, friction: 20 } */
-    stiff: SpringConfig;
-    /** slow: { tension: 280, friction: 60 } */
-    slow: SpringConfig;
-  };
+export const config: {
+  /** default: { tension: 170, friction: 26 } */
+  default: SpringConfig
+  /** gentle: { tension: 120, friction: 14 } */
+  gentle: SpringConfig
+  /** wobbly: { tension: 180, friction: 12 } */
+  wobbly: SpringConfig
+  /** stiff: { tension: 210, friction: 20 } */
+  stiff: SpringConfig
+  /** slow: { tension: 280, friction: 60 } */
+  slow: SpringConfig
+}
 
-  export class Spring<
-    S extends object,
-    DS extends object,
-  > extends PureComponent<SpringProps<S, DS>> {}
+export class Spring<S extends object, DS extends object> extends PureComponent<
+  SpringProps<S, DS>
+> {}
 
-  export function interpolate(
-    parent: number[],
-    config: (...args: number[]) => any,
-  ): any;
+export function interpolate(
+  parent: number[],
+  config: (...args: number[]) => any
+): any
 
-  export const animated: {
-    [Tag in keyof JSX.IntrinsicElements]: ComponentClass<
-      JSX.IntrinsicElements[Tag]
-    >
-  };
+export const animated: {
+  [Tag in keyof JSX.IntrinsicElements]: ComponentClass<
+    JSX.IntrinsicElements[Tag]
+  >
+}
 
-  type TransitionKeyProps = string | number;
-  type TransitionItemProps = string | number | object;
+type TransitionKeyProps = string | number
+type TransitionItemProps = string | number | object
 
-  type TransitionProps<S extends object, DS extends object = {}> = {
-    /**
-     * Will skip rendering the component if true and write to the dom directly
-     * @default false
-     */
-    native?: boolean;
-    /**
-     * Spring config ({ tension, friction })
-     * @default config.default
-     */
-    config?: SpringConfig | ((key: string) => SpringConfig);
-    /**
-     * Base styles
-     * @default {}
-     */
-    from?: DS;
-    /**
-     * Animated styles when the component is mounted
-     * @default {}
-     */
-    enter?: DS;
-    /**
-     * Unmount styles
-     * @default {}
-     */
-    leave?: DS;
+interface TransitionProps<S extends object, DS extends object = {}> {
+  /**
+   * Will skip rendering the component if true and write to the dom directly
+   * @default false
+   */
+  native?: boolean
+  /**
+   * Spring config ({ tension, friction })
+   * @default config.default
+   */
+  config?: SpringConfig | ((key: string) => SpringConfig)
+  /**
+   * Base styles
+   * @default {}
+   */
+  from?: DS
+  /**
+   * Animated styles when the component is mounted
+   * @default {}
+   */
+  enter?: DS
+  /**
+   * Unmount styles
+   * @default {}
+   */
+  leave?: DS
 
-    update?: DS;
-    /**
-     * A collection of unique keys that must match with the childrens order
-     * Can be omitted if children/render aren't an array
-     * Can be a function, which then acts as a key-accessor which is useful when you use the items prop
-     * @default {}
-     */
-    keys?: ((params: TransitionItemProps) => TransitionKeyProps) | Array<TransitionKeyProps> | TransitionKeyProps;
-    /**
-     * Optional. Let items refer to the actual data and from/enter/leaver/update can return per-object styles
-     * @default {}
-     */
-    items?: Array<TransitionItemProps> | TransitionItemProps;
+  update?: DS
+  /**
+   * A collection of unique keys that must match with the childrens order
+   * Can be omitted if children/render aren't an array
+   * Can be a function, which then acts as a key-accessor which is useful when you use the items prop
+   * @default {}
+   */
+  keys?:
+    | ((params: TransitionItemProps) => TransitionKeyProps)
+    | Array<TransitionKeyProps>
+    | TransitionKeyProps
+  /**
+   * Optional. Let items refer to the actual data and from/enter/leaver/update can return per-object styles
+   * @default {}
+   */
+  items?: Array<TransitionItemProps> | TransitionItemProps
 
-    children?: SpringRendererFunc<S, DS> | Array<SpringRendererFunc<S, DS>>;
+  children?: SpringRendererFunc<S, DS> | Array<SpringRendererFunc<S, DS>>
 
-    render?: SpringRendererFunc<S, DS> | Array<SpringRendererFunc<S, DS>>;
-  };
+  render?: SpringRendererFunc<S, DS> | Array<SpringRendererFunc<S, DS>>
+}
 
-  export class Transition<
-    S extends object,
-    DS extends object,
-  > extends PureComponent<TransitionProps<S, DS>> {}
+export class Transition<
+  S extends object,
+  DS extends object
+> extends PureComponent<TransitionProps<S, DS>> {}
 
-  type TrailKeyProps = string | number;
-  type TrailKeyItemProps = string | number | object;
+type TrailKeyProps = string | number
+type TrailKeyItemProps = string | number | object
 
-  type TrailProps<S extends object, DS extends object = {}> = {
-    native?: boolean;
+interface TrailProps<S extends object, DS extends object = {}> {
+  native?: boolean
 
-    config?: SpringConfig | ((key: string) => SpringConfig);
+  config?: SpringConfig | ((key: string) => SpringConfig)
 
-    from?: DS;
+  from?: DS
 
-    to?: DS;
+  to?: DS
 
-    keys?: ((params: TrailKeyItemProps) => TrailKeyProps) | Array<TrailKeyProps> | TrailKeyProps;
+  keys?:
+    | ((params: TrailKeyItemProps) => TrailKeyProps)
+    | Array<TrailKeyProps>
+    | TrailKeyProps
 
-    children?: SpringRendererFunc<S, DS> | Array<SpringRendererFunc<S, DS>>;
+  children?: SpringRendererFunc<S, DS> | Array<SpringRendererFunc<S, DS>>
 
-    render?: SpringRendererFunc<S, DS> | Array<SpringRendererFunc<S, DS>>;
-  };
+  render?: SpringRendererFunc<S, DS> | Array<SpringRendererFunc<S, DS>>
+}
 
-  export class Trail<
-    S extends object,
-    DS extends object,
-  > extends PureComponent<TrailProps<S, DS>> {}
+export class Trail<S extends object, DS extends object> extends PureComponent<
+  TrailProps<S, DS>
+> {}
 
-  type ParallaxProps<S extends object, DS extends object = {}> = {
-    pages: number;
+interface ParallaxProps<S extends object, DS extends object = {}> {
+  pages: number
 
-    config?: SpringConfig | ((key: string) => SpringConfig);
+  config?: SpringConfig | ((key: string) => SpringConfig)
 
-    scrolling?: boolean;
+  scrolling?: boolean
 
-    horizontal?: boolean;
-  };
+  horizontal?: boolean
+}
 
-  export class Parallax<
-    S extends object,
-    DS extends object,
-  > extends PureComponent<ParallaxProps<S, DS>> {}
+export class Parallax<
+  S extends object,
+  DS extends object
+> extends PureComponent<ParallaxProps<S, DS>> {}
 
-  type ParallaxLayerProps<S extends object, DS extends object = {}> = {
-    factor?: number;
+interface ParallaxLayerProps<S extends object, DS extends object = {}> {
+  factor?: number
 
-    offset?: number;
+  offset?: number
 
-    speed?: number;
-  };
+  speed?: number
+}
 
-  export class ParallaxLayer<
-    S extends object,
-    DS extends object,
-  > extends PureComponent<ParallaxLayerProps<S, DS>> {}
+export class ParallaxLayer<
+  S extends object,
+  DS extends object
+> extends PureComponent<ParallaxLayerProps<S, DS>> {}
 
-  type KeyframesProps<S extends object, DS extends object = {}> = {
-    script: (next: Function) => Function;
-  };
+interface KeyframesProps<S extends object, DS extends object = {}> {
+  state: string
+}
 
-  export class Keyframes<
-    S extends object,
-    DS extends object,
-  > extends Component<KeyframesProps<S, DS>> {}
+export class Keyframes<S extends object, DS extends object> extends Component<
+  KeyframesProps<S, DS>
+> {
+  static create<S extends object, DS extends object>(
+    primitive: ComponentType
+  ): (states: object) => (props: object) => Keyframes<S, DS>
+  static Spring<S extends object, DS extends object>(
+    states: object
+  ): (props: object) => Keyframes<S, DS>
+  static Trail<S extends object, DS extends object>(
+    states: object
+  ): (props: object) => Keyframes<S, DS>
+  static Transition<S extends object, DS extends object>(
+    states: object
+  ): (props: object) => Keyframes<S, DS>
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "prebuild": "rimraf dist",
     "build": "rollup -c",
     "prepare": "npm run build",
-    "test": "jest"
+    "test": "jest",
+    "test:ts": "tsc --noEmit"
   },
   "husky": {
     "hooks": {
@@ -80,7 +81,8 @@
     "rollup-plugin-commonjs": "^9.1.3",
     "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-size-snapshot": "^0.6.0",
-    "rollup-plugin-uglify": "^4.0.0"
+    "rollup-plugin-uglify": "^4.0.0",
+    "typescript": "^2.9.2"
   },
   "peerDependencies": {
     "prop-types": "15.x.x",

--- a/tests/ts-test.tsx
+++ b/tests/ts-test.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react'
+
+import { Keyframes } from '../'
+
+const Container = Keyframes.Spring({
+  open: {
+    from: { opacity: 0 },
+    to: { opacity: 1 },
+  },
+  close: {
+    to: { opacity: 0 },
+  },
+})
+
+export const NoTypeWarnings = (
+  <Container state="open">
+    {(styles: { opacity: number }) => <div style={styles}>Hello</div>}
+  </Container>
+)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "noUnusedLocals": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noEmitOnError": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["es2016", "dom"]
+  },
+  "include": ["tests/**/*.tsx"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5532,6 +5532,10 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+typescript@^2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
+
 ua-parser-js@^0.7.18:
   version "0.7.18"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.18.tgz#a7bfd92f56edfb117083b69e31d2aa8882d4b1ed"


### PR DESCRIPTION
I noticed that the Keyframes typings don't seem to be in sync with the latest version anymore, so this should fix that.

Also changed the type defs to use interfaces as that actually allows people to extend them. For instance ParallaxLayer should also accept a `style` prop. You should be able to easily extend that as end-user. 

Also, I have no idea what all these S, DS generics are. They seem to be used all over the place even when they're not being used in the actual type / interface. See `ParallaxLayerProps` for instance. Maybe the original author knows why thats there?