### PR TITLE
Update Transition type definition

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,11 +1,11 @@
 {
   "dist/addons.umd.js": {
-    "bundled": 16003,
+    "bundled": 16024,
     "minified": 5898,
     "gzipped": 2150
   },
   "dist/web.umd.js": {
-    "bundled": 86075,
+    "bundled": 86161,
     "minified": 35541,
     "gzipped": 12021
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -162,9 +162,15 @@ interface TransitionProps<S extends object, DS extends object = {}> {
    */
   items?: Array<TransitionItemProps> | TransitionItemProps
 
-  children?: SpringRendererFunc<S, DS> | Array<SpringRendererFunc<S, DS>>
+  children?:
+    | SpringRendererFunc<S, DS>
+    | Array<SpringRendererFunc<S, DS>>
+    | boolean
 
-  render?: SpringRendererFunc<S, DS> | Array<SpringRendererFunc<S, DS>>
+  render?:
+    | SpringRendererFunc<S, DS>
+    | Array<SpringRendererFunc<S, DS>>
+    | boolean
 }
 
 export class Transition<

--- a/readme.md
+++ b/readme.md
@@ -15,14 +15,14 @@ import { Spring, ... } from 'react-spring/dist/universal'
 
 # Table of Contents 👇
 
-* [What is it?](#what-is-it-)
-* [Why do we need yet another?](#why-do-we-need-yet-another-)
-* [Links](#links-)
-* [Basic overview](#basic-overview-)
-* [Interpolation](#interpolation-)
-* [Render props](#render-props-)
-* [Native rendering](#native-rendering-)
-* [React-native and other targets](#react-native-and-other-targets-)
+- [What is it?](#what-is-it-)
+- [Why do we need yet another?](#why-do-we-need-yet-another-)
+- [Links](#links-)
+- [Basic overview](#basic-overview-)
+- [Interpolation](#interpolation-)
+- [Render props](#render-props-)
+- [Native rendering](#native-rendering-)
+- [React-native and other targets](#react-native-and-other-targets-)
 
 # What is it? 🤔
 
@@ -67,7 +67,6 @@ react-spring is a cooked down fork of Christopher Chedeau's [animated](https://g
 react-spring builds upon animated's foundation, making it leaner and more flexible. It inherits react-motions declarative api and goes to great lengths to simplify it. It has lots of useful primitives, can interpolate mostly everything and last but not least, can animate by committing directly to the dom instead of re-rendering a component frame-by-frame.
 
 For a more detailed explanation read [Why React needed yet another animation library](https://medium.com/@drcmda/why-react-needed-yet-another-animation-library-introducing-react-spring-8212e424c5ce).
-
 
 # Links 🔗
 
@@ -127,11 +126,22 @@ Given a single child instead of a list you can toggle between two components.
 import { Transition } from 'react-spring'
 
 <Transition from={{ opacity: 0 }} enter={{ opacity: 1 }} leave={{ opacity: 0 }}>
-    {toggle ? ComponentA : ComponentB}
+    {toggle
+        ? styles => <ComponentA style={styles} />
+        : styles => <ComponentB style={styles} />
+    }
 </Transition>
 ```
 
-If you need to toggle a single child, that is also possible: `{toggle && Component}`
+If you need to toggle a single child, that is also possible.
+
+```jsx
+import { Transition } from 'react-spring'
+
+<Transition from={{ opacity: 0 }} enter={{ opacity: 1 }} leave={{ opacity: 0 }}>
+    {visible && (styles => <SingleComponent style={styles} />)}
+</Transition>
+```
 
 #### Trails and staggered animations ([Demo](https://codesandbox.io/embed/vvmv6x01l5))
 
@@ -278,7 +288,6 @@ const AnimatedView = animated(View)
 
 This project exists thanks to all the people who contribute. [[Contribute]](CONTRIBUTING.md).
 <a href="graphs/contributors"><img src="https://opencollective.com/react-spring/contributors.svg?width=890" /></a>
-
 
 # Backers
 

--- a/src/Transition.js
+++ b/src/Transition.js
@@ -52,12 +52,10 @@ export default class Transition extends React.PureComponent {
     children: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.func),
       PropTypes.func,
-      PropTypes.bool,
     ]),
     render: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.func),
       PropTypes.func,
-      PropTypes.bool,
     ]),
   }
 

--- a/src/Transition.js
+++ b/src/Transition.js
@@ -52,10 +52,12 @@ export default class Transition extends React.PureComponent {
     children: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.func),
       PropTypes.func,
+      PropTypes.bool,
     ]),
     render: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.func),
       PropTypes.func,
+      PropTypes.bool,
     ]),
   }
 


### PR DESCRIPTION
This PR reflects some of the thought put out in https://github.com/drcmda/react-spring/issues/26#issuecomment-406741416.

From reading some of the recent PR's I can see that having a literal boolean type on `Transition` has been discussed in #84 but never seemed to have gotten implemented.
The TS compiler throws an error if a literal boolean false type is being substituted for this PR's basic boolean type. A simple type discrepancy. Therefore `boolean` is used instead.

I'll modify as needed.

Thanks for a great lib @drcmda 👍 