### PR TITLE
Micro perf/avoid array copying

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -5,8 +5,8 @@
     "gzipped": 2150
   },
   "dist/web.umd.js": {
-    "bundled": 88675,
-    "minified": 35810,
-    "gzipped": 12181
+    "bundled": 88945,
+    "minified": 35931,
+    "gzipped": 12242
   }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -5,8 +5,8 @@
     "gzipped": 2150
   },
   "dist/web.umd.js": {
-    "bundled": 88945,
-    "minified": 35931,
+    "bundled": 88954,
+    "minified": 35932,
     "gzipped": 12242
   }
 }

--- a/src/targets/web/fix-auto.js
+++ b/src/targets/web/fix-auto.js
@@ -12,7 +12,7 @@ export default function fixAuto(props, callback) {
   const { from, to } = props
 
   // Dry-route props back if nothing's using 'auto' in there
-  if (![...getValues(from), ...getValues(to)].some(check)) return
+  if (!(getValues(from).some(check) || getValues(to).some(check))) return
   // Fetch render v-dom
   const element = renderChildren(props, convertValues(props))
   // A spring can return undefined/null, check against that (#153)


### PR DESCRIPTION
This has no actual change in file sizes, size snapshot on master was outdated - u can see the real snapshot diff [here](https://github.com/drcmda/react-spring/commit/93f2c38547ea1889cd99212db87d6df05706b0c8#diff-29fd455fe4a1c8d19c5e5b1420ce14faL8).

the point of this PR is to avoid copying 2 arrays with spread (results of `getValues `) and creating 3 temporary arrays that have to be GCed (mentioned copies + a wrapper array that hold their values together in a way that `[]#.some` could be used)