### PR TITLE
Optimize unitless

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,10 @@
     ["@babel/preset-stage-3", { "loose": true }],
     "@babel/preset-react"
   ],
-  "plugins": [["transform-react-remove-prop-types", { "removeImport": true }]],
+  "plugins": [
+    ["transform-react-remove-prop-types", { "removeImport": true }],
+    "codegen"
+  ],
   "env": {
     "test": {
       "presets": [

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -5,8 +5,8 @@
     "gzipped": 2150
   },
   "dist/web.umd.js": {
-    "bundled": 88954,
-    "minified": 35932,
-    "gzipped": 12242
+    "bundled": 89134,
+    "minified": 36026,
+    "gzipped": 12294
   }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -5,8 +5,8 @@
     "gzipped": 2150
   },
   "dist/web.umd.js": {
-    "bundled": 89134,
-    "minified": 36026,
-    "gzipped": 12294
+    "bundled": 88522,
+    "minified": 35817,
+    "gzipped": 12264
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@types/react": "^16.4.6",
     "babel-core": "7.0.0-bridge.0",
     "babel-jest": "^23.4.2",
+    "babel-plugin-codegen": "^3.0.0",
     "babel-plugin-transform-react-remove-prop-types": "0.4.13",
     "enzyme": "^3.4.4",
     "enzyme-adapter-react-16": "^1.2.0",
@@ -93,6 +94,7 @@
   },
   "dependencies": {
     "@babel/runtime": "7.0.0-beta.51",
+    "@emotion/memoize": "^0.6.5",
     "memoize-one": "^4.0.0"
   },
   "jest": {

--- a/src/targets/web/globals.js
+++ b/src/targets/web/globals.js
@@ -1,61 +1,12 @@
+import memoize from '@emotion/memoize'
 import * as Globals from '../../animated/Globals'
 import colorNames from '../shared/colors'
 import createInterpolation from '../shared/interpolation'
 import fixAuto from './fix-auto'
 
-const isUnitlessNumber = {
-  animationIterationCount: true,
-  borderImageOutset: true,
-  borderImageSlice: true,
-  borderImageWidth: true,
-  boxFlex: true,
-  boxFlexGroup: true,
-  boxOrdinalGroup: true,
-  columnCount: true,
-  columns: true,
-  flex: true,
-  flexGrow: true,
-  flexPositive: true,
-  flexShrink: true,
-  flexNegative: true,
-  flexOrder: true,
-  gridRow: true,
-  gridRowEnd: true,
-  gridRowSpan: true,
-  gridRowStart: true,
-  gridColumn: true,
-  gridColumnEnd: true,
-  gridColumnSpan: true,
-  gridColumnStart: true,
-  fontWeight: true,
-  lineClamp: true,
-  lineHeight: true,
-  opacity: true,
-  order: true,
-  orphans: true,
-  tabSize: true,
-  widows: true,
-  zIndex: true,
-  zoom: true,
-  // SVG-related properties
-  fillOpacity: true,
-  floodOpacity: true,
-  stopOpacity: true,
-  strokeDasharray: true,
-  strokeDashoffset: true,
-  strokeMiterlimit: true,
-  strokeOpacity: true,
-  strokeWidth: true,
-}
-
-const prefixKey = (prefix, key) =>
-  prefix + key.charAt(0).toUpperCase() + key.substring(1)
-const prefixes = ['Webkit', 'Ms', 'Moz', 'O']
-
-Object.keys(isUnitlessNumber).forEach(prop =>
-  prefixes.forEach(
-    pre => (isUnitlessNumber[prefixKey(pre, prop)] = isUnitlessNumber[prop])
-  )
+const isUnitlessNumberRegExp = codegen.require('./is-unitless-prop')
+const isUnitlessNumber = memoize(
+  isUnitlessNumberRegExp.bind(isUnitlessNumberRegExp)
 )
 
 function dangerousStyleValue(name, value, isCustomProperty) {
@@ -64,7 +15,7 @@ function dangerousStyleValue(name, value, isCustomProperty) {
     !isCustomProperty &&
     typeof value === 'number' &&
     value !== 0 &&
-    !(isUnitlessNumber.hasOwnProperty(name) && isUnitlessNumber[name])
+    !isUnitlessNumber(name)
   )
     return value + 'px'
   // Presumes implicit 'px' suffix for unitless numbers
@@ -74,28 +25,31 @@ function dangerousStyleValue(name, value, isCustomProperty) {
 Globals.injectInterpolation(createInterpolation)
 Globals.injectColorNames(colorNames)
 Globals.injectBugfixes(fixAuto)
-Globals.injectApplyAnimatedValues((instance, props) => {
-  if (instance.nodeType && instance.setAttribute !== undefined) {
-    const { style, ...attributes } = props
+Globals.injectApplyAnimatedValues(
+  (instance, props) => {
+    if (instance.nodeType && instance.setAttribute !== undefined) {
+      const { style, ...attributes } = props
 
-    // Set styles ...
-    for (let styleName in style) {
-      if (!style.hasOwnProperty(styleName)) continue
-      var isCustomProperty = styleName.indexOf('--') === 0
-      var styleValue = dangerousStyleValue(
-        styleName,
-        style[styleName],
-        isCustomProperty
-      )
-      if (styleName === 'float') styleName = 'cssFloat'
-      if (isCustomProperty) instance.style.setProperty(styleName, styleValue)
-      else instance.style[styleName] = styleValue
-    }
+      // Set styles ...
+      for (let styleName in style) {
+        if (!style.hasOwnProperty(styleName)) continue
+        var isCustomProperty = styleName.indexOf('--') === 0
+        var styleValue = dangerousStyleValue(
+          styleName,
+          style[styleName],
+          isCustomProperty
+        )
+        if (styleName === 'float') styleName = 'cssFloat'
+        if (isCustomProperty) instance.style.setProperty(styleName, styleValue)
+        else instance.style[styleName] = styleValue
+      }
 
-    // Set attributes ...
-    for (let name in attributes) {
-      if (instance.getAttribute(name))
-        instance.setAttribute(name, attributes[name])
-    }
-  } else return false
-}, style => style)
+      // Set attributes ...
+      for (let name in attributes) {
+        if (instance.getAttribute(name))
+          instance.setAttribute(name, attributes[name])
+      }
+    } else return false
+  },
+  style => style
+)

--- a/src/targets/web/is-unitless-prop.js
+++ b/src/targets/web/is-unitless-prop.js
@@ -1,0 +1,51 @@
+const props = {
+  animationIterationCount: true,
+  borderImageOutset: true,
+  borderImageSlice: true,
+  borderImageWidth: true,
+  boxFlex: true,
+  boxFlexGroup: true,
+  boxOrdinalGroup: true,
+  columnCount: true,
+  columns: true,
+  flex: true,
+  flexGrow: true,
+  flexPositive: true,
+  flexShrink: true,
+  flexNegative: true,
+  flexOrder: true,
+  gridRow: true,
+  gridRowEnd: true,
+  gridRowSpan: true,
+  gridRowStart: true,
+  gridColumn: true,
+  gridColumnEnd: true,
+  gridColumnSpan: true,
+  gridColumnStart: true,
+  fontWeight: true,
+  lineClamp: true,
+  lineHeight: true,
+  opacity: true,
+  order: true,
+  orphans: true,
+  tabSize: true,
+  widows: true,
+  zIndex: true,
+  zoom: true,
+  // SVG-related properties
+  fillOpacity: true,
+  floodOpacity: true,
+  stopOpacity: true,
+  strokeDasharray: true,
+  strokeDashoffset: true,
+  strokeMiterlimit: true,
+  strokeOpacity: true,
+  strokeWidth: true,
+}
+
+const prefixes = ['Webkit', 'Ms', 'Moz', 'O']
+
+// eslint-disable-next-line import/no-commonjs
+module.exports = `/^(${prefixes.join('|')})?(${Object.keys(props).join(
+  '|'
+)})$/i`

--- a/yarn.lock
+++ b/yarn.lock
@@ -659,6 +659,10 @@
     lodash "^4.17.5"
     to-fast-properties "^2.0.0"
 
+"@emotion/memoize@^0.6.5":
+  version "0.6.5"
+  resolved "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.6.5.tgz#f868c314b889e7c3d84868a1d1cc323fbb40ca86"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
@@ -1116,6 +1120,13 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-codegen@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/babel-plugin-codegen/-/babel-plugin-codegen-3.0.0.tgz#8e832d0e08a95665b185603b779116dd83473ae2"
+  dependencies:
+    babel-plugin-macros "^2.2.1"
+    require-from-string "^2.0.2"
+
 babel-plugin-istanbul@^4.1.6:
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
@@ -1128,6 +1139,12 @@ babel-plugin-istanbul@^4.1.6:
 babel-plugin-jest-hoist@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#e61fae05a1ca8801aadee57a6d66b8cefaf44167"
+
+babel-plugin-macros@^2.2.1:
+  version "2.4.0"
+  resolved "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.4.0.tgz#6c5f9836e1f6c0a9743b3bab4af29f73e437e544"
+  dependencies:
+    cosmiconfig "^5.0.5"
 
 babel-plugin-syntax-object-rest-spread@^6.13.0:
   version "6.13.0"
@@ -1686,6 +1703,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
 cosmiconfig@^5.0.2:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-5.0.5.tgz#a809e3c2306891ce17ab70359dc8bdf661fe2cd0"
+  dependencies:
+    is-directory "^0.3.1"
+    js-yaml "^3.9.0"
+    parse-json "^4.0.0"
+
+cosmiconfig@^5.0.5:
+  version "5.0.6"
+  resolved "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.6.tgz#dca6cf680a0bd03589aff684700858c81abeeb39"
   dependencies:
     is-directory "^0.3.1"
     js-yaml "^3.9.0"
@@ -4893,6 +4918,10 @@ request@^2.83.0:
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
 
 require-main-filename@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Again - the change [is minimal](https://github.com/drcmda/react-spring/commit/eb6a8f961070d904ccc309c4034d7934589844d0#diff-29fd455fe4a1c8d19c5e5b1420ce14faR7) when it comes to the lib's weight, but it does a one important thing - it "folds" the expression which creates `isUnitless` test. Previously there was a top level loop adding properties to the lookup table and thus making it harder/impossible to tree shake this. Now it's still not treeshakeable but it's at least going into good direction.

I'm looking into how to restructure few things to support tree-shaking better, so expect some weirdo PRs in following days 😉 

⚠️ also I need to warn you that I don't actually test those changes, hopefully I haven't made any stupid mistake though, please review it with caution (not sure if u have extensive test suite here)