### PR TITLE
Namespace color matchers

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -5,8 +5,8 @@
     "gzipped": 2150
   },
   "dist/web.umd.js": {
-    "bundled": 88954,
-    "minified": 35932,
-    "gzipped": 12242
+    "bundled": 89134,
+    "minified": 36026,
+    "gzipped": 12294
   }
 }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -5,8 +5,8 @@
     "gzipped": 2150
   },
   "dist/web.umd.js": {
-    "bundled": 89134,
-    "minified": 36026,
-    "gzipped": 12294
+    "bundled": 89063,
+    "minified": 35987,
+    "gzipped": 12291
   }
 }

--- a/src/targets/shared/colorMatchers.js
+++ b/src/targets/shared/colorMatchers.js
@@ -1,0 +1,18 @@
+// const INTEGER = '[-+]?\\d+';
+const NUMBER = '[-+]?\\d*\\.?\\d+'
+const PERCENTAGE = NUMBER + '%'
+
+function call() {
+  return '\\(\\s*(' + Array.prototype.slice.call(arguments).join(')\\s*,\\s*(') + ')\\s*\\)'
+}
+
+export const rgb = new RegExp('rgb' + call(NUMBER, NUMBER, NUMBER))
+export const rgba = new RegExp('rgba' + call(NUMBER, NUMBER, NUMBER, NUMBER))
+export const hsl = new RegExp('hsl' + call(NUMBER, PERCENTAGE, PERCENTAGE))
+export const hsla = new RegExp(
+  'hsla' + call(NUMBER, PERCENTAGE, PERCENTAGE, NUMBER)
+)
+export const hex3 = /^#([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})$/
+export const hex4 = /^#([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})$/
+export const hex6 = /^#([0-9a-fA-F]{6})$/
+export const hex8 = /^#([0-9a-fA-F]{8})$/

--- a/src/targets/shared/normalizeColors.js
+++ b/src/targets/shared/normalizeColors.js
@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 import colorNames from './colors'
+import * as matchers from './colorMatchers'
 
 export default function normalizeColor(color) {
   let match
@@ -149,29 +150,6 @@ function hslToRgb(h, s, l) {
     (Math.round(g * 255) << 16) |
     (Math.round(b * 255) << 8)
   )
-}
-
-// var INTEGER = '[-+]?\\d+';
-const NUMBER = '[-+]?\\d*\\.?\\d+'
-const PERCENTAGE = NUMBER + '%'
-
-function call() {
-  return (
-    '\\(\\s*(' +
-    Array.prototype.slice.call(arguments).join(')\\s*,\\s*(') +
-    ')\\s*\\)'
-  )
-}
-
-var matchers = {
-  rgb: new RegExp('rgb' + call(NUMBER, NUMBER, NUMBER)),
-  rgba: new RegExp('rgba' + call(NUMBER, NUMBER, NUMBER, NUMBER)),
-  hsl: new RegExp('hsl' + call(NUMBER, PERCENTAGE, PERCENTAGE)),
-  hsla: new RegExp('hsla' + call(NUMBER, PERCENTAGE, PERCENTAGE, NUMBER)),
-  hex3: /^#([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})$/,
-  hex4: /^#([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})$/,
-  hex6: /^#([0-9a-fA-F]{6})$/,
-  hex8: /^#([0-9a-fA-F]{8})$/,
 }
 
 function parse255(str) {


### PR DESCRIPTION
Size diff [here](https://github.com/drcmda/react-spring/commit/338e3fb5823e77df590c8ac663254bc35b40552b#diff-29fd455fe4a1c8d19c5e5b1420ce14faR7). Again it's really minimal but IMHO still worth doing - anything internal that is an object merely for namespacing purposes should be a namespace object - then rollup will be able to just use each a single variable in each using "call site" rather than an object property.