### PR TITLE
Support entry for react-native

### DIFF
--- a/documentation/Introduction.mdx
+++ b/documentation/Introduction.mdx
@@ -55,7 +55,7 @@ import { Spring } from 'react-spring'
 
 ```jsx
 // React-native
-import { Spring } from 'react-spring/dist/native'
+import { Spring } from 'react-spring'
 
 // React-konva
 import { Spring } from 'react-spring/dist/konva'
@@ -64,7 +64,7 @@ import { Spring } from 'react-spring/dist/konva'
 import { Spring } from 'react-spring/dist/universal'
 ```
 
-The default export points to react-dom. If you want to animate react-native refer to /dist/native, and /dist/universal for any other target. Each target defines platform specific constants (colors, units, etc.). The universal target is the least specific.
+The default export points to react-dom when running in web and to react-native when running in react-native. If you want to animate any other target refer to /dist/universal. Each target defines platform specific constants (colors, units, etc.). The universal target is the least specific.
 
 In react-native you can still use the native keyword for more performance, create your own animated-components by calling into the animated function.
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Animate React with ease",
   "main": "dist/web.cjs.js",
   "module": "dist/web.js",
+  "react-native": "dist/native.js",
   "typings": "index.d.ts",
   "files": [
     "dist",


### PR DESCRIPTION
This PR allows importing `react-spring` directly in `react-native` without having to refer to `react-spring/dist/native`.

```js
// before
import { Spring } from 'react-spring/dist/native'

// after
import { Spring } from 'react-spring'
```