### PR TITLE
Add missing plugin-proposal-class-properties dependency to examples.

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -25,6 +25,7 @@
     "devDependencies": {
         "@babel/cli": "7.0.0",
         "@babel/core": "7.0.0",
+        "@babel/plugin-proposal-class-properties": "^7.0.0",
         "@babel/plugin-proposal-decorators": "^7.0.0",
         "@babel/plugin-syntax-dynamic-import": "^7.0.0",
         "@babel/preset-env": "7.0.0",


### PR DESCRIPTION
When running "npm install" & "npm build" on the examples directory I get the following traceback:

```
npm start

> react-spring-examples@1.0.0 start /Users/timo/workspace/react/react-spring/examples
> webpack-dev-server --progress --colors --env development

 10% building modules 1/1 modules 0 activeℹ ｢wds｣: Project is running at http://localhost:8080/
ℹ ｢wds｣: webpack output is served from /
ℹ ｢wds｣: Content not from webpack is served from /Users/timo/workspace/react/react-spring/examples
✖ ｢wdm｣:
ERROR in ./index.js
Module build failed (from ./node_modules/babel-loader/lib/index.js):
Error: Cannot find module '@babel/plugin-proposal-class-properties' from '/Users/timo/workspace/react/react-spring/examples'
    at Function.module.exports [as sync] (/Users/timo/workspace/react/react-spring/examples/node_modules/resolve/lib/sync.js:43:15)
    at resolveStandardizedName (/Users/timo/workspace/react/react-spring/examples/node_modules/@babel/core/lib/config/files/plugins.js:101:31)
    at resolvePlugin (/Users/timo/workspace/react/react-spring/examples/node_modules/@babel/core/lib/config/files/plugins.js:54:10)
    at loadPlugin (/Users/timo/workspace/react/react-spring/examples/node_modules/@babel/core/lib/config/files/plugins.js:62:20)
    at createDescriptor (/Users/timo/workspace/react/react-spring/examples/node_modules/@babel/core/lib/config/config-descriptors.js:154:9)
    at items.map (/Users/timo/workspace/react/react-spring/examples/node_modules/@babel/core/lib/config/config-descriptors.js:109:50)
    at Array.map (<anonymous>)
    at createDescriptors (/Users/timo/workspace/react/react-spring/examples/node_modules/@babel/core/lib/config/config-descriptors.js:109:29)
    at createPluginDescriptors (/Users/timo/workspace/react/react-spring/examples/node_modules/@babel/core/lib/config/config-descriptors.js:105:10)
    at alias (/Users/timo/workspace/react/react-spring/examples/node_modules/@babel/core/lib/config/config-descriptors.js:63:49)
 @ multi (webpack)-dev-server/client?http://localhost:8080 index.js main[1]
ℹ ｢wdm｣: Failed to compile.
```

This can be fixed by adding 'plugin-proposal-class-properties dependency' to the package dependencies in examples/package.json.