### PR TITLE
Add explicit type definition for Parallax ref

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ import {
   ReactNode,
   ComponentClass,
   ComponentType,
+  Ref
 } from 'react'
 
 export type SpringEasingFunc = (t: number) => number
@@ -224,12 +225,16 @@ interface ParallaxProps<S extends object, DS extends object = {}> {
   scrolling?: boolean
 
   horizontal?: boolean
+
+  ref?: Ref<Parallax>
 }
 
 export class Parallax<
-  S extends object,
-  DS extends object
-> extends PureComponent<ParallaxProps<S, DS> & S> {}
+  S extends object = {},
+  DS extends object = {}
+> extends PureComponent<ParallaxProps<S, DS> & S> {
+  scrollTo: (offset: number) => void
+}
 
 interface ParallaxLayerProps<S extends object, DS extends object = {}> {
   factor?: number


### PR DESCRIPTION
Related to https://github.com/drcmda/react-spring/issues/26 since this improves on the Typescript definitions.

Noticed when using the Parallax component that the ref didn't have any types describing that you can use the `.scrollTo()` function. With this, Typescript users will get complete typing and won't need to create their own or cast the ref to `any`.