### PR TITLE
Properly infer generic typings for Spring/Transition/Trail

### DIFF
--- a/src/Trail.js
+++ b/src/Trail.js
@@ -18,7 +18,7 @@ export default class Trail extends React.PureComponent {
     keys: PropTypes.oneOfType([PropTypes.func, PropTypes.array, PropTypes.any]),
     /** An array of items to be displayed, use this if you need access to the actual items when distributing values as functions (see above) */
     items: PropTypes.oneOfType([PropTypes.array, PropTypes.any]).isRequired,
-    /** An array of functions (props => view) */
+    /** A single function-child that receives the individual item and return a functional component (item, index) => props => view) */
     children: PropTypes.func.isRequired,
     /** When true the trailing order is switched, it will then trail bottom to top */
     reverse: PropTypes.bool,


### PR DESCRIPTION
Currently in `<Spring />`, `<Transition />`, and `<Trail />`, the child function parameter types cannot be inferred. As an example:

```jsx
<Spring from={{ opacity: 0 }} to={{ opacity: 1 }}>
	{(styles) => <div style={styles} />}
</Spring>
```

Here `styles` would be of type `any`. With the proposed changes however, `styles` would be of type `{ opacity: number, [key: string]: any }`. The `[key: string]: any` is an unfortunate side effect of needing to support passthrough props. I don't see passthrough props documented anywhere but they are used in [this demo](https://codesandbox.io/embed/oln44nx8xq) (`toggle`) so I made sure to support it in the types. If that isn't actually part of the API I can take out the `& WeakObject`'s. and make this a bit cleaner.

For `Transition` I made the assumption that the child function is called with the intersection of `initial`, `from`, `enter`, `leave`, and `update` if these props were supplied with different types. As another example:

```jsx
<Transition
	from={{ opacity: 0 }}
	enter={{ opacity: 1, height: 100 }}
	leave={{ width: 0 }}>
	{(styles) => <div style={styles} />}
</Transition>
```

Here `styles` would be of type:

```ts
{
	height: number,
	opacity: number,
	width: number
	[key: string]: any,
}
```

Reference https://github.com/drcmda/react-spring/issues/26 again since this improves more on the Typescript support.
