### PR TITLE
Add ParallaxLayer position update hook

### DIFF
--- a/API-OVERVIEW.md
+++ b/API-OVERVIEW.md
@@ -307,7 +307,7 @@ const Container = Keyframes.create(MyOwnPrimitive)({ ... })
 import { Parallax, ParallaxLayer } from 'react-spring'
 
 <Parallax pages={3} scrolling={false} horizontal ref={ref => this.parallax = ref}>
-    <ParallaxLayer offset={0} speed={0.5}>
+    <ParallaxLayer offset={0} speed={0.5} onPositionChange={(to, height) => {}}>
         <span onClick={() => this.parallax.scrollTo(1)}>
             Layers can contain anything
         </span>

--- a/API.md
+++ b/API.md
@@ -209,12 +209,15 @@ class ParallaxLayer extends React.PureComponent {
     offset: PropTypes.number,
     // Speed (and direction) it scrolls there, can be positive or negative
     speed: PropTypes.number,
+    // ParallaxLayer position change hook
+    onPositionChange: PropTypes.func
   }
 
   static defaultProps = {
     factor: 1,
     offset: 0,
     speed: 0,
+    onPositionChange: function(to, height) {},
   }
 }
 ```

--- a/documentation/Parallax.mdx
+++ b/documentation/Parallax.mdx
@@ -19,7 +19,7 @@ import { Parallax, ParallaxLayer } from 'react-spring'
 
 ```jsx
 <Parallax pages={3} scrolling={false} horizontal ref={ref => this.parallax = ref}>
-  <ParallaxLayer offset={0} speed={0.5}>
+  <ParallaxLayer offset={0} speed={0.5} onPositionChange={(to, height) => {}}>
     <span onClick={() => this.parallax.scrollTo(1)}>
       Layers can contain anything
     </span>

--- a/src/targets/web/Parallax.js
+++ b/src/targets/web/Parallax.js
@@ -24,12 +24,15 @@ export class ParallaxLayer extends React.PureComponent {
     offset: PropTypes.number,
     /** shifts the layer in accordance to its offset, values can be positive or negative */
     speed: PropTypes.number,
+    /** ParallaxLayer position change hook */
+    onPositionChange: PropTypes.func
   }
 
   static defaultProps = {
     factor: 1,
     offset: 0,
     speed: 0,
+    onPositionChange: function(to, height) {}
   }
 
   componentDidMount() {
@@ -56,6 +59,7 @@ export class ParallaxLayer extends React.PureComponent {
     if (!immediate)
       controller(this.animatedTranslate, { to, ...config }, impl).start()
     else this.animatedTranslate.setValue(to)
+    this.props.onPositionChange(to, height)
   }
 
   setHeight(height, immediate = false) {


### PR DESCRIPTION
@drcmda This hook is intended to allow users to tap into the current state of a layer position so that they can animate elements according to those values. Please let me know if there could be a better way to handle this.