### PR TITLE
Types: Fix TransitionItemProps not recognising booleans

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -125,7 +125,7 @@ export const animated: {
 }
 
 type TransitionKeyProps = string | number
-type TransitionItemProps = string | number | object
+type TransitionItemProps = boolean | string | number | object
 
 interface TransitionProps<S extends object, DS extends object = {}> {
   /**
@@ -264,8 +264,8 @@ export class Keyframes<S extends object, DS extends object> extends PureComponen
   ): (props: object) => Keyframes<S | Pick<SpringProps<S,DS>, Exclude<keyof SpringProps<S,DS>, "to">>, DS>
   static Trail<S extends object, DS extends object>(
     states: object
-  ): (props: object) => Keyframes<S | Pick<TrailProps<S,DS>, Exclude<keyof TrailProps<S,DS>, "to">>, DS> 
+  ): (props: object) => Keyframes<S | Pick<TrailProps<S,DS>, Exclude<keyof TrailProps<S,DS>, "to">>, DS>
   static Transition<S extends object, DS extends object>(
     states: object
-  ): (props: object) => Keyframes<S | Pick<TransitionProps<S,DS>, Exclude<keyof TransitionProps<S,DS>, "to">>, DS> 
+  ): (props: object) => Keyframes<S | Pick<TransitionProps<S,DS>, Exclude<keyof TransitionProps<S,DS>, "to">>, DS>
 }


### PR DESCRIPTION
Regarding https://github.com/drcmda/react-spring/issues/275, after trying `react-spring 6.1.0`, the type issue on `TransitionItemProps` has yet to be resolved, causing an error in Typescript due to props type mismatch. (PR https://github.com/drcmda/react-spring/pull/270 doesn't seem to target this issue)

This PR adds the missing `boolean` type to the `TransitionItemProps` that gets used by the `Transition` component, as documented [here](http://react-spring.surge.sh/transition#props)

The live example of using `TransitionItemProps` as a `boolean` toggle to control mount/unmount component is demonstrated in the 2nd example in the above URL and is tested to be functioning this way.

Reference https://github.com/drcmda/react-spring/issues/26 again since this improves more on the Typescript support.