### PR TITLE
Hotfix typo surrounding array destructuring.

### DIFF
--- a/documentation/Hooks-manual.mdx
+++ b/documentation/Hooks-manual.mdx
@@ -27,7 +27,7 @@ You can use this hook to define and update data. The data you pass in consists o
 
 ```jsx
 function ClasslessComponent() {
-  [props] = useSpring({ opacity: 1, from: { opacity: 0 } })
+  const [props] = useSpring({ opacity: 1, from: { opacity: 0 } })
   return <animated.div style={props}>i will fade in</animated.div>
 }
 ```
@@ -46,7 +46,7 @@ You can update spring data simply by overwriting the hook, it will remember prev
 
 ```jsx
 function ClasslessComponent({ opacity }) {
-  [props] = useSpring({ opacity, from: { opacity: 0 } })
+  const [props] = useSpring({ opacity, from: { opacity: 0 } })
   return <animated.div style={props}>i will fade in</animated.div>
 }
 ```
@@ -55,7 +55,7 @@ There is another way to update your spring outside of React, it returns an updat
 
 ```jsx
 function ClasslessComponent() {
-  [props, set] = useSpring({ pos: [0, 0] })
+  const [props, set] = useSpring({ pos: [0, 0] })
   useEffect(() => {
     const handler = ({ clientX, clientY }) => set({ pos: [clientX, clientY] })
     window.addEventListener('mousemove', handler)


### PR DESCRIPTION
Add `const` before array destructuring