### PR TITLE
Fix small typo in Keyframes Docs

### DIFF
--- a/documentation/Keyframes.mdx
+++ b/documentation/Keyframes.mdx
@@ -24,7 +24,7 @@ import { Keyframes } from 'react-spring'
   A slot can take:
 
   <ul>
-    <li>An object consisting of preperties</li>
+    <li>An object consisting of properties</li>
     <li>An array of objects, which then forms a chained animation</li>
     <li>A function that allows you to script or form loops</li>
   </ul>

--- a/documentation/Keyframes.mdx
+++ b/documentation/Keyframes.mdx
@@ -18,7 +18,7 @@ import { Keyframes } from 'react-spring'
   <code>Keyframes</code> allow you to chain, compose and orchestrate animations.
 </p>
 <p>
-  <span className="highlight">Keyframes is a factory that extends either spings or trails.</span> You start by defining one or many named-slots in which you place the properties you want to animate. By default all unknown props are interpolate as "to". You can use <i>all</i> spring props otherwise: from, config, reset, etc. It creates a component that bears a speacial "state" prop, which receives the name of one of the slots. It will execute it and run its animations.
+  <span className="highlight">Keyframes is a factory that extends either spings or trails.</span> You start by defining one or many named-slots in which you place the properties you want to animate. By default all unknown props are interpolate as "to". You can use <i>all</i> spring props otherwise: from, config, reset, etc. It creates a component that bears a special "state" prop, which receives the name of one of the slots. It will execute it and run its animations.
 </p>
 <p>
   A slot can take:


### PR DESCRIPTION
#### Changes
* `preperties` => `properties`
* `spaecial` => `special`