### PR TITLE
Fix typo in Spring docs

### DIFF
--- a/documentation/Spring.mdx
+++ b/documentation/Spring.mdx
@@ -109,7 +109,7 @@ import CodeMirror from './resources/Codemirror'
 </p> 
 
 * colors (names, rgb, rgba, hsl, hsla, gradients)
-* absolute lenghts (cm, mm, in, px, pt, pc)
+* absolute lengths (cm, mm, in, px, pt, pc)
 * relative lengths (em, ex, ch, rem, vw, vh, vmin, vmax, %)
 * angles (deg, rad, grad, turn)
 * flex and grid units (fr, etc)


### PR DESCRIPTION
It's tiny enough that I feel silly creating a PR 🙃