### PR TITLE
[typescript] Fix animated components to be ForwardRefExoticComponent

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ import {
   ComponentClass,
   ComponentType,
   Ref,
+  ForwardRefExoticComponent,
 } from 'react'
 
 export type SpringEasingFunc = (t: number) => number
@@ -104,9 +105,9 @@ export function interpolate(
 ): any
 
 export const animated: {
-  <P>(comp: ComponentType<P>): ComponentType<P>
+  <P>(comp: ComponentType<P>): ForwardRefExoticComponent<P>
 } & {
-  [Tag in keyof JSX.IntrinsicElements]: ComponentClass<
+  [Tag in keyof JSX.IntrinsicElements]: ForwardRefExoticComponent<
     JSX.IntrinsicElements[Tag]
   >
 }


### PR DESCRIPTION
Adjusts the return component type for `animated('div')` and `animated.div`, since they actually return the result from `forwardRef`

see [forwardRef definition](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a8323887d04e77b954142e388e4026cedc8e405d/types/react/index.d.ts#L693)