### PR TITLE
Update readme documentation link to HTTPS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ React-spring is a spring physics based animation library for React.
 
 For a more detailed explanation read [Why React needed yet another animation library](https://medium.com/@drcmda/why-react-needed-yet-another-animation-library-introducing-react-spring-8212e424c5ce).
 
-Full documentation and examples here: [react-spring.surge.sh](http://react-spring.surge.sh/)
+Full documentation and examples here: [react-spring.surge.sh](https://react-spring.surge.sh/)
 
 # What others say
 


### PR DESCRIPTION
I noticed the docs site seems to support HTTPS (https://react-spring.surge.sh) and figured it would be better to link to that URL from the readme. 