### PR TITLE
TypeScript TransitionProps doesn't extends SpringProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -135,6 +135,8 @@ interface TransitionProps<
   TEnter extends object = {},
   TLeave extends object = {},
   TUpdate extends object = {}
+  SpringProps extends object = {},
+  DS extends object = {},
 > {
   /**
    * First-render initial values, if present overrides "from" on the first render pass. It can be "null" to skip first mounting transition. Otherwise it can take an object or a function (item => object)
@@ -165,6 +167,11 @@ interface TransitionProps<
    * @default {}
    */
   leave?: TLeave
+  /**
+   * Callback when the animation comes to a still-stand
+   */
+  onRest?: (ds: DS) => void
+  
   /**
    * Values that apply to elements that are neither entering nor leaving (you can use this to update present elements), or: item => values
    */

--- a/index.d.ts
+++ b/index.d.ts
@@ -168,6 +168,10 @@ interface TransitionProps<
    */
   leave?: TLeave
   /**
+   * Callback when the animation starts to animate
+   */
+  onStart?: () => void
+  /**
    * Callback when the animation comes to a still-stand
    */
   onRest?: (ds: DS) => void

--- a/index.d.ts
+++ b/index.d.ts
@@ -134,7 +134,7 @@ interface TransitionProps<
   TFrom extends object = {},
   TEnter extends object = {},
   TLeave extends object = {},
-  TUpdate extends object = {}
+  TUpdate extends object = {},
   SpringProps extends object = {},
   DS extends object = {},
 > {


### PR DESCRIPTION
TransitionProps does not contain properties such as onStart or onRest.