### PR TITLE
@types/react/index has no exported member 'ForwardRefExoticComponent'

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,6 @@ import {
   ComponentClass,
   ComponentType,
   Ref,
-  ForwardRefExoticComponent,
 } from 'react'
 
 export type SpringEasingFunc = (t: number) => number
@@ -117,9 +116,9 @@ export function interpolate(
 ): any
 
 export const animated: {
-  <P>(comp: ComponentType<P>): ForwardRefExoticComponent<P>
+  <P>(comp: ComponentType<P>): ComponentType<P>
 } & {
-  [Tag in keyof JSX.IntrinsicElements]: ForwardRefExoticComponent<
+  [Tag in keyof JSX.IntrinsicElements]: ComponentType<
     JSX.IntrinsicElements[Tag]
   >
 }


### PR DESCRIPTION
reverting commit 281993d as it introduced this issue... I looked it up in the latest react version, there is no exported member 'ForwardRefExoticComponent'