### PR TITLE
[chore] remove overwritten property

### DIFF
--- a/src/Trail.js
+++ b/src/Trail.js
@@ -6,10 +6,6 @@ import { toArray } from './shared/helpers'
 
 export default class Trail extends React.PureComponent {
   static propTypes = {
-    /** Item keys (the same keys you'd hand over to react in a list). If you specify items, keys can be an accessor function (item => item.key) */
-    keys: PropTypes.arrayOf(
-      PropTypes.oneOfType([PropTypes.string, PropTypes.number])
-    ).isRequired,
     /** Base values, optional */
     from: PropTypes.object,
     /** Animates to ... */


### PR DESCRIPTION
The type specification for the `keys` property of Trail was defined twice (lines `10` and `18`), and defined differently in each case. This PR removes what looks like the incorrect definition (which also didn't match its docstring, as `keys` can be a function that maps an item to its key).

This will also result in no behavioural change, as when multiple properties are defined with the same name in an object literal, the last one is used. So this deleted code was being ignored anyway.

I found this in the alerts for this project on LGTM.com, and there are [a bunch of remaining alerts](https://lgtm.com/projects/g/drcmda/react-spring/alerts) that would probably also be good to look at.

*(Full disclosure: I'm part of the team behind LGTM.com)*